### PR TITLE
ARGOeu/ARGO#98 Added role for pig client configuration

### DIFF
--- a/roles/pig_client/tasks/main.yml
+++ b/roles/pig_client/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Configure pig related parameter
+  tags: pig_client_config
+  lineinfile: dest=/etc/pig/conf/pig.properties
+              regexp="^pig.logfile"
+              line="pig.logfile=/tmp/pig-err.log"
+              state=present
+              backup=yes
+
+- name: Insert comment for pig related parameter
+  tags: pig_client_config
+  lineinfile: dest=/etc/pig/conf/pig.properties
+              regexp="^# File Parameter"
+              insertbefore="^pig.logfile"
+              line="# File Parameter for pig exception dump."
+              state=present
+              backup=yes

--- a/standalone.yml
+++ b/standalone.yml
@@ -9,4 +9,5 @@
     - { role: has_certificate , tags: has_certificate }
     - { role: consumer        , tags: consumer        }
     - { role: mongodb         , tags: mongodb         }
+    - { role: pig_client      , tags: pig_client      }
     - { role: webapi          , tags: webapi          }


### PR DESCRIPTION
This pull request has been opened as a follow up to [1]. The pig dump exception file path is now configured via ansible. No parameters need to be specified in python script calls. 

[1] https://github.com/ARGOeu/argo-compute-engine/pull/75

please review /cc @pkoro @kaggis