### PR TITLE
Change cron definitions after standalone->bin folder change

### DIFF
--- a/roles/consumer/tasks/main.yml
+++ b/roles/consumer/tasks/main.yml
@@ -44,7 +44,7 @@
         state=present
         minute=0
         hour=0
-        job="/usr/libexec/ar-compute/standalone/job_cycle.py -d $(/bin/date --utc --date '-1 day' +\%Y-\%m-\%d)"
+        job="/usr/libexec/ar-compute/bin/job_cycle.py -d $(/bin/date --utc --date '-1 day' +\%Y-\%m-\%d)"
 
 - name: Configure ar-compute job cycle hourly cron 
   tags: compute_config
@@ -54,7 +54,7 @@
         state=present
         minute=55
         hour=*
-        job="/usr/libexec/ar-compute/standalone/job_cycle.py -d $(/bin/date --utc  +\%Y-\%m-\%d)"
+        job="/usr/libexec/ar-compute/bin/job_cycle.py -d $(/bin/date --utc  +\%Y-\%m-\%d)"
 
 - name: Create job directories
   tags: sync_config


### PR DESCRIPTION
After renaming the executable script folder standalone -> bin ([see ref]), ansible cron job configurations must be changed to reflect the new path.

[see ref]:https://github.com/ARGOeu/argo-compute-engine/commit/d81f934f5cd5f35d069726d03a22ec39f1a52b50




 