### PR TITLE
ARGO-242 Add key files explicitly in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .DS_Store
 setup.sh
 .*.sw?
-hostcert.pem
-hostkey.pem
+roles/has_certificate/files/*.key

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contains Ansible playbook for the deployment of the ARGO datastore and API servi
 
 ### Things to do before deployment
 
-- Obtain a key/certificate pair from a trusted CA and after place them both under roles/has_certificate/files with names `hostkey.pem` and `hostcert.pem` respectively.
+- Obtain a key/certificate pair from a trusted CA and after place them both under roles/has_certificate/files with names `{{inventory_hostname}}.key` and `{{inventory_hostname}}.pem` respectively. As `{{inventory_hostname}}` use the exact name used within the `inventory` file. 
 - Edit inventory and replace `webapi.node` with the hostname that you intend to deploy the API onto. 
 
 ### Prerequisites
@@ -36,7 +36,7 @@ Contains Ansible playbook for the deployment of the ARGO Web UI service. The pla
 
 ### Things to do before deployment
 
-- Obtain a key/certificate pair from a trusted CA and after place them both under roles/has_certificate/files with names `hostkey.pem` and `hostcert.pem` respectively.
+- Obtain a key/certificate pair from a trusted CA and after place them both under roles/has_certificate/files with names `{{inventory_hostname}}.key` and `{{inventory_hostname}}.pem` respectively. As `{{inventory_hostname}}` use the exact name used within the `inventory` file. 
 - Edit inventory and replace `webui.node` with the hostname that you intend to deploy the Web UI onto. 
 - Edit `roles/webui/vars/main.yml` file and change the values of the `certificate_password` and `keystore_password` variables to a stronger value.
 
@@ -63,7 +63,7 @@ Contains Ansible playbook for the deployment of all ARGO components. The play is
 
 ### Things to do before deployment
 
-- Obtain a key/certificate pair from a trusted CA and after place them both under roles/has_certificate/files with names `hostkey.pem` and `hostcert.pem` respectively.
+- Obtain a key/certificate pair from a trusted CA and after place them both under roles/has_certificate/files with names `{{inventory_hostname}}.key` and `{{inventory_hostname}}.pem` respectively. As `{{inventory_hostname}}` use the exact name used within the `inventory` file. 
 - Edit inventory and replace `standalone.node` with the hostname that you intend to deploy the complete ARGO stack onto. 
 
 ### Prerequisites

--- a/roles/has_certificate/defaults/main.yml
+++ b/roles/has_certificate/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+cert_path: /etc/grid-security/hostcert.pem
+key_path: /etc/grid-security/hostkey.pem

--- a/roles/has_certificate/tasks/main.yml
+++ b/roles/has_certificate/tasks/main.yml
@@ -7,13 +7,13 @@
 
 - name: Copy host x509 certificate onto host
   tags: certificate
-  copy: src=hostcert.pem
+  copy: src={{ inventory_hostname }}.pem
         dest={{ cert_path }} backup=yes
         owner=root group=root mode=0644
 
 - name: Copy host x509 key onto host
   tags: certificate
-  copy: src=hostkey.pem
+  copy: src={{ inventory_hostname }}.key
         dest={{ key_path }} backup=yes
         owner=root group=root mode=0400
 


### PR DESCRIPTION
# Description

This changes how key/cert files are handled by the Ansible role has certificate. Public certificate files are made public whereas private key files are ignored from git repo. 

please review /cc @themiszamani 