### PR TITLE
ARGO-242 add sudo true and remove remote username from play

### DIFF
--- a/standalone.yml
+++ b/standalone.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: standalone
-  user: root
+  sudo: true
   roles:
     - { role: firewall        , tags: firewall        }
     - { role: repos           , tags: repos           }

--- a/webapi.yml
+++ b/webapi.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: webapi
-  user: root
+  sudo: true
   roles:
     - { role: firewall, tags: firewall }
     - { role: repos, tags: repos }


### PR DESCRIPTION
# Description

There is no need to define remote username within the playbook as this is set inside the configuration file. However, one needs to define play should run in sudo mode (in case another user is selected via `ansible_user` variable). 