### PR TITLE
ARGO-242 Mongo bind interfaces configuration

### DIFF
--- a/group_vars/standalone
+++ b/group_vars/standalone
@@ -1,6 +1,6 @@
 ---
 
-mongo_bind_interface: 127.0.0.1
+mongo_bind_interfaces: 127.0.0.1
 
 cert_path: /etc/grid-security/hostcert.pem
 key_path: /etc/grid-security/hostkey.pem

--- a/group_vars/webapi
+++ b/group_vars/webapi
@@ -1,6 +1,6 @@
 ---
 
-mongo_bind_interface: 0.0.0.0
+mongo_bind_interfaces: 0.0.0.0
 
 cert_path: /etc/pki/tls/certs/localhost.crt
 key_path: /etc/pki/tls/private/localhost.key

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Comma separated list of IPs mongo service should bind to
+mongo_bind_interfaces: 127.0.0.1,192.168.0.33

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -4,24 +4,10 @@
   tags: mongoDB-packages
   yum: name={{ item }} state=present
   with_items:
-    - mongodb-org
-    - mongodb-org-server
+    - mongodb-org-3.0.7
+    - mongodb-org-server-3.0.7
 
-- name: check mongo version
-  shell: rpm -q --queryformat '[%{RPMTAG_VERSION}]' mongodb-org
-  ignore_errors: True
-  register: mongo_version
-
-- name: Bind mongod for version 3.0.0
-  lineinfile: dest=/etc/mongod.conf
-              regexp="^bind_ip = "
-              line="bind_ip = 127.0.0.1,{{ ansible_eth0.ipv4.address }}"
-              state=present
-              backup=yes
-  notify: restart mongo
-  when: mongo_version is defined and mongo_version.stdout == "3.0.0"
-
-- name: Bind mongod for version 3.0.7
+- name: Bind mongod processes to an interface
   lineinfile: >
               dest=/etc/mongod.conf
               regexp="\ \ bindIp"
@@ -29,9 +15,8 @@
               state=present
               backup=yes
   notify: restart mongo
-  when: mongo_version is defined and mongo_version.stdout == "3.0.7"
 
-- name: Fix issue with mongo init script in version 3.0.7
+- name: Fix issue with mongo init script
   lineinfile: >
               dest=/etc/mongod.conf
               regexp="\ \ pidFilePath"
@@ -39,7 +24,6 @@
               state=present
               backup=yes
   notify: restart mongo
-  when: mongo_version is defined and mongo_version.stdout == "3.0.7"
 
 - name: Increase soft nproc limits
   copy: src=etc/security/limits.d/99-mongodb-nproc.conf

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -7,7 +7,21 @@
     - mongodb-org
     - mongodb-org-server
 
-- name: Bind mongod processes to an interface
+- name: check mongo version
+  shell: rpm -q --queryformat '[%{RPMTAG_VERSION}]' mongodb-org
+  ignore_errors: True
+  register: mongo_version
+
+- name: Bind mongod for version 3.0.0
+  lineinfile: dest=/etc/mongod.conf
+              regexp="^bind_ip = "
+              line="bind_ip = 127.0.0.1,{{ ansible_eth0.ipv4.address }}"
+              state=present
+              backup=yes
+  notify: restart mongo
+  when: mongo_version is defined and mongo_version.stdout == "3.0.0"
+
+- name: Bind mongod for version 3.0.7
   lineinfile: >
               dest=/etc/mongod.conf
               regexp="\ \ bindIp"
@@ -15,8 +29,9 @@
               state=present
               backup=yes
   notify: restart mongo
+  when: mongo_version is defined and mongo_version.stdout == "3.0.7"
 
-- name: Fix issue with mongo init script
+- name: Fix issue with mongo init script in version 3.0.7
   lineinfile: >
               dest=/etc/mongod.conf
               regexp="\ \ pidFilePath"
@@ -24,6 +39,7 @@
               state=present
               backup=yes
   notify: restart mongo
+  when: mongo_version is defined and mongo_version.stdout == "3.0.7"
 
 - name: Increase soft nproc limits
   copy: src=etc/security/limits.d/99-mongodb-nproc.conf

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -7,11 +7,11 @@
     - mongodb-org-3.0.7
     - mongodb-org-server-3.0.7
 
-- name: Bind mongod processes to an interface
+- name: Bind mongod processes to one or more interfaces
   lineinfile: >
               dest=/etc/mongod.conf
               regexp="\ \ bindIp"
-              line='  bindIp: {{ mongo_bind_interface }}'
+              line='  bindIp: {{ mongo_bind_interfaces }}'
               state=present
               backup=yes
   notify: restart mongo


### PR DESCRIPTION
# Description

Change parameter name `mongo_bind_interface` to plural (`mongo_bind_interfaces`) and give an example within role `defaults`. Should be merged after #31 