### PR TITLE
ARGO-242 Service name has changed

### DIFF
--- a/roles/consumer/handlers/main.yml
+++ b/roles/consumer/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: restart consumer
-  service: name=ar-consumer state=restarted
+  service: name=argo-egi-consumer state=restarted
 

--- a/roles/consumer/handlers/main.yml
+++ b/roles/consumer/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 
-- name: restart consumer
+- name: restart egi consumer
   service: name=argo-egi-consumer state=restarted
 

--- a/roles/consumer/tasks/main.yml
+++ b/roles/consumer/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Install consumer from ar project
   tags: ar-packages
   yum: name=argo-egi-consumer state=latest enablerepo={{ enabled_argo_repo }}
-  notify: restart consumer
+  notify: restart egi consumer
 
 - name: Consumer configuration
   tags: consumer_config

--- a/roles/repos/files/etc/yum.repos.d/cloudera-cdh5.repo
+++ b/roles/repos/files/etc/yum.repos.d/cloudera-cdh5.repo
@@ -1,3 +1,4 @@
+[cloudera-cdh5]
 # Packages for Cloudera's Distribution for Hadoop, Version 5, on RedHat	or CentOS 6 x86_64
 name=Cloudera's Distribution for Hadoop, Version 5
 baseurl=http://archive.cloudera.com/cdh5/redhat/6/x86_64/cdh/5/


### PR DESCRIPTION
# Description

Fix in one handler where the old service name was still used and not updated to the new one. 