### PR TITLE
ARGO-290 Make cache directory configurable via vars file

### DIFF
--- a/roles/webui/tasks/main.yml
+++ b/roles/webui/tasks/main.yml
@@ -23,6 +23,9 @@
 - name: Create download directory
   file: path={{ lavoisier_home }} state=directory
 
+- name: Create cache directory
+  file: path={{ cache_directory }} state=directory
+
 - name: Download lavoisier zip file
   get_url: url=https://github.com/ARGOeu/{{ argo_web }}/archive/{{ branch_name }}.zip
            dest={{ lavoisier_home }}/{{ branch_name }}.zip


### PR DESCRIPTION
# Description

This is a rather minimal and simple PR. One task is added in order to make sure the cache directory folder exists (in the case a user wants to provide something other than the default, which is `/tmp`). 

please review /cc @dpavlos 