### PR TITLE
ARGO-290 Copy source files as templates

### DIFF
--- a/roles/webui/tasks/main.yml
+++ b/roles/webui/tasks/main.yml
@@ -14,8 +14,8 @@
   notify: restart webui
 
 - name: Copy files to setup HOME_LAVOISIER
-  copy: src={{ item }} dest=/etc/profile.d/{{ item }}
-        owner=root group=root mode=0644
+  template: src={{ item }}.j2 dest=/etc/profile.d/{{ item }}
+            owner=root group=root mode=0644
   with_items:
     - lavoisier.sh
     - lavoisier.csh

--- a/roles/webui/templates/lavoisier.csh.j2
+++ b/roles/webui/templates/lavoisier.csh.j2
@@ -1,2 +1,2 @@
 # File to export the variable HOME_LAVOISIER.
-export HOME_LAVOISIER=/var/www/lavoisier
+setenv HOME_LAVOISIER "{{ lavoisier_home }}"

--- a/roles/webui/templates/lavoisier.sh.j2
+++ b/roles/webui/templates/lavoisier.sh.j2
@@ -1,2 +1,2 @@
 # File to export the variable HOME_LAVOISIER.
-setenv HOME_LAVOISIER "/var/www/lavoisier"
+export HOME_LAVOISIER={{ lavoisier_home }}


### PR DESCRIPTION
# Description

Files copied onto the target host that define the LAVOSIER_HOME env variable are changed to templates instead of files. 

please review /cc @dpavlos 