### PR TITLE
ARGO-345 Fix in POEM cron job 

### DIFF
--- a/roles/consumer/tasks/main.yml
+++ b/roles/consumer/tasks/main.yml
@@ -108,7 +108,7 @@
         minute=2
         hour=0
         user=root
-        job="/usr/libexec/argo-egi-connectors/poem-connector.py -c /etc/argo-egi-connectors/{{ item.key | lower }}-customer.conf"
+        job="/usr/libexec/argo-egi-connectors/poem-connector.py {% if item.value.prefilter is not defined %} -np {% endif %} -c /etc/argo-egi-connectors/{{ item.key | lower }}-customer.conf"
         state=present
   with_dict: tenants
 


### PR DESCRIPTION
# Description 

A change has been made on the connectors package that allows us to not fetch the complete POEM profiles list that is needed by the prefilter in the usual case. Using this change a flag is conditionally passed onto the related cron job per tenant. 

