### PR TITLE
ARGO-242 Better conditional handling of non egi consumer configurations

### DIFF
--- a/roles/consumer/handlers/main.yml
+++ b/roles/consumer/handlers/main.yml
@@ -7,3 +7,8 @@
   service: name=argo-{{ item.key | lower }}-consumer state=restarted
   with_dict: tenants
 
+# TODO: Make following handler task tenant unaware
+- name: restart all non egi consumers
+  service: name=argo-{{ item.key | lower }}-consumer state=restarted
+  with_dict: tenants
+  when: item.key|lower != "egi"

--- a/roles/consumer/tasks/main.yml
+++ b/roles/consumer/tasks/main.yml
@@ -51,21 +51,25 @@
   with_dict: tenants
   notify: restart all consumers
 
-- name: Copy out init scripts for consumers
+# TODO: Make following task tenant unaware
+- name: Copy out init scripts for non egi consumers
   tags: 
     - consumer_config
   template: src=consumer.init.j2
             dest=/etc/init.d/argo-{{ item.key | lower }}-consumer
             owner=root group=root mode=0755
   with_dict: tenants
-  notify: restart all consumers
+  when: item.key|lower != "egi"
+  notify: restart all non egi consumers
 
+# TODO: Make following task tenant unaware
 - name: Create copies of python wrappers for non egi consumers
   tags: 
     - consumer_config
   file: path=/usr/bin/argo-{{ item.key | lower }}-wrapper-consumer.py
         state=link src=/usr/bin/argo-egi-consumer.py
   with_dict: tenants
+  when: item.key|lower != "egi"
 
 - name: Enable and start consumer services
   tags: 

--- a/roles/consumer/templates/consumer.init.j2
+++ b/roles/consumer/templates/consumer.init.j2
@@ -7,7 +7,7 @@
 . /etc/rc.d/init.d/functions
 PROG_NAME="argo-{{ item.key | lower }}-consumer"
 CONFIG="/etc/argo-{{ item.key | lower }}-consumer/consumer.conf"
-DAEMON_PATH="/usr/bin/argo-{{ item.key | lower }}-wrapper-consumer.py"
+DAEMON_PATH="/usr/bin/argo-{{ item.key | lower }}{% if item.key|lower != "egi" %}-wrapper{% endif %}-consumer.py"
 
 case "$1" in
 start)


### PR DESCRIPTION
# Description

A lot of the consumer configuration for the case of the EGI tenant comes straight from the `argo-egi-consumer` ARGO package. This pull request tries to change such basic stuff on the consumer nodes so as not to overwrite such files for the EGI case (only duplicate required files for additional tenants). 

please review /cc @dpavlos 