### PR TITLE
ARGO-242 Fix pymongo version

### DIFF
--- a/roles/consumer/tasks/main.yml
+++ b/roles/consumer/tasks/main.yml
@@ -8,9 +8,9 @@
   tags: ar-packages
   yum: name=python-pip state=present
 
-- name: Upgrade pymongo to latest available version
+- name: Install pymongo fixed version
   tags: ar-packages
-  pip: name=pymongo state=latest
+  pip: name=pymongo state=present version=3.2.1
 
 - name: Install egi consumer package from ar project
   tags: 


### PR DESCRIPTION
# Description

This change sets the version of the pymongo (installed via pip) package to a specific version. It is suggested so as not to have (in the future) different versions of the specific utility package between devel and production. 

please review /cc @dpavlos 