### PR TITLE
ARGO-356 Modify nrpe configuration workflow

### DIFF
--- a/roles/is_monitored/files/ar-dev-api.cfg
+++ b/roles/is_monitored/files/ar-dev-api.cfg
@@ -1,1 +1,0 @@
-command[check_disk]=/usr/lib64/nagios/plugins/check_disk -w 10% -c 5%

--- a/roles/is_monitored/tasks/main.yml
+++ b/roles/is_monitored/tasks/main.yml
@@ -9,14 +9,18 @@
     - nagios-plugins-disk
 
 - name: Copy nrpe configuration file on host
-  tags: monitoring
-  copy: src=ar-dev-api.cfg
-        dest={{ nrpe_conf_path }}/ar-dev-api.cfg backup=yes
-        owner=root group=root mode=0644
+  tags: 
+    - monitoring
+    - nrpe_checks
+  template: src=nrpe.cfg.j2
+            dest={{ nrpe_conf_path }}/nrpe.cfg backup=yes
+            owner=root group=root mode=0644
   notify: restart nrpe
 
 - name: Modify nrpe configuration itself
-  tags: monitoring
+  tags: 
+    - monitoring
+    - nrpe_hosts
   lineinfile: dest=/etc/nagios/nrpe.cfg
               regexp="^allowed_hosts="
               line="allowed_hosts={{ nrpe_allowed_hosts }}"

--- a/roles/is_monitored/templates/nrpe.cfg.j2
+++ b/roles/is_monitored/templates/nrpe.cfg.j2
@@ -1,0 +1,5 @@
+{% if inventory_hostname in groups.standalone %}
+command[check_consumer_proc]=/usr/lib64/nagios/plugins/check_procs -a '/usr/bin/argo-egi-consumer.py' -c 1:10
+command[check_consumer_log]=/usr/bin/sudo /usr/local/bin/check_consumer_log
+{% endif %}
+command[check_disk]=/usr/lib64/nagios/plugins/check_disk -w 10% -c 5%


### PR DESCRIPTION
# Description

This PR introduces a change in the nrpe configuration way that is used. 

Instead of copying a file with just one check few more checks are added in the case of a host that acts as an ARGO consumer. Note that this role is not inhereted within any playbook, it is just a utility role as described also in the README.md file. 

please review /cc @dpavlos 