### PR TITLE
ARGO-354 Ansible deploy for monitoring engine

### DIFF
--- a/group_vars/monitoring_engine
+++ b/group_vars/monitoring_engine
@@ -1,0 +1,8 @@
+---
+cert_path: /etc/pki/tls/certs/localhost.crt
+key_path: /etc/pki/tls/private/localhost.key
+
+iptables_rules:
+  input:
+    - { dport: "80",   proto: "tcp", policy: "accept"}
+    - { dport: "443",  proto: "tcp", policy: "accept"}

--- a/inventory
+++ b/inventory
@@ -10,3 +10,6 @@ poem.node
 
 [webui]
 webui.node
+
+[monitoring_engine]
+monitoring_engine.node

--- a/monitoring_engine.yml
+++ b/monitoring_engine.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: monitoring_engine
+  user: root
+  roles:
+    - { role: firewall, tags: firewall }
+    - { role: repos,    tags: repos    }
+    - { role: has_certificate, tags: certificate }
+    - { role: monitoring_engine,    tags: monitoring_engine    }

--- a/roles/monitoring_engine/defaults/main.yml
+++ b/roles/monitoring_engine/defaults/main.yml
@@ -1,0 +1,21 @@
+
+nagios_components:
+  - { name: argo-ncg                , repo: argo-prod }
+  - { name: argo-msg-nagios         , repo: argo-prod }
+  
+nagios_server: localhost
+probes_type: local
+nagios_admin_email: contact@nagiosadmin.localhost
+vo: ops
+enable_unicore_probes: "0"
+metric_config_file: /etc/ncg-metric-config.d/local.conf
+gocdb_root_url: https://goc.egi.eu/gocdbpi
+cert_status: Production
+nagios_role: PROJECT
+include_empty_hosts: "0"
+enable_notifications: "0"
+check_hosts: "0"
+tenant: TENANT_A
+poem_root_url: http://localhost/poem
+include_proxy_checks: "0"
+include_msg_checks_recv: "0"

--- a/roles/monitoring_engine/tasks/main.yml
+++ b/roles/monitoring_engine/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Install Nagios
+  yum: name=nagios-4.0.8-1.el6.srce.x86_64.rpm state=present enablerepo=nagios
+  
+- name: Install NCG and MSG conponents
+  yum: name={{ item.name }} state=latest enablerepo={{ item.repo }}
+  with_items: nagios_components

--- a/roles/monitoring_engine/templates/ncg.conf.j2
+++ b/roles/monitoring_engine/templates/ncg.conf.j2
@@ -1,0 +1,65 @@
+# Configuration uses Apache-like format
+# as defined by Perl module Config::General.
+# For further details see:
+#   http://search.cpan.org/dist/Config-General/
+
+# Global variables which can be used in module
+# configuration (e.g. LDAP_ADDRESS=$BDII).
+# Variables in curly brackets are environment
+# variables.
+
+NAGIOS_SERVER = {{ nagios_server }}
+PROBES_TYPE= {{ probes_type }}
+NAGIOS_ADMIN = {{ nagios_admin_email }}
+VO = {{ vo }}
+ENABLE_UNICORE_PROBES= {{ enable_unicore_probes }}
+METRIC_CONFIG_FILE = {{ metric_config_file }}
+
+<NCG::SiteSet>
+  <GOCDB>
+    GOCDB_ROOT_URL={{ gocdb_root_url }}
+    CERT_STATUS={{ cert_status }}
+  </GOCDB>
+</NCG::SiteSet>
+<NCG::SiteInfo>
+  <GOCDB>
+    GOCDB_ROOT_URL={{ gocdb_root_url }}
+  </GOCDB>
+</NCG::SiteInfo>
+
+<NCG::ConfigGen>
+  <Nagios>
+    TEMPLATES_DIR = /usr/share/grid-monitoring/config-gen/nagios
+    OUTPUT_DIR = /etc/nagios/wlcg.d
+    NRPE_OUTPUT_DIR = /etc/nagios/nrpe/
+    NAGIOS_ROLE = {{ nagios_role }}
+    INCLUDE_EMPTY_HOSTS = {{ include_empty_hosts }}
+    ENABLE_NOTIFICATIONS = {{ enable_notifications }}
+    CHECK_HOSTS = {{ check_hosts }}
+    TENANT = {{ tenant }}
+  </Nagios>
+</NCG::ConfigGen>
+
+<NCG::LocalMetrics>
+  <POEM>
+    POEM_ROOT_URL = {{ poem_root_url }}
+  </POEM>
+  <File>
+    DB_FILE=/etc/ncg/ncg.localdb
+  </File>
+</NCG::LocalMetrics>
+
+<NCG::LocalMetricsAttrs>
+  <Active>
+    GOCDB_ROOT_URL={{ gocdb_root_url }}
+    ENABLE_UNICORE_PROBES=$ENABLE_UNICORE_PROBES
+    INCLUDE_PROXY_CHECKS = {{ include_proxy_checks }}
+    INCLUDE_MSG_CHECKS_RECV = {{ include_msg_checks_recv }}
+  </Active>
+  <File>
+    DB_FILE=/etc/ncg/ncg.localdb
+  </File>
+</NCG::LocalMetricsAttrs>
+
+include ncg.conf.d/*.conf
+

--- a/roles/repos/files/etc/yum.repos.d/nagios.repo
+++ b/roles/repos/files/etc/yum.repos.d/nagios.repo
@@ -1,0 +1,5 @@
+[nagios]
+name=Nagios Repository
+baseurl=http://ftp.srce.hr/srce-redhat/base/el6/$basearch
+enabled=0
+gpgcheck=0

--- a/roles/repos/tasks/main.yml
+++ b/roles/repos/tasks/main.yml
@@ -32,3 +32,10 @@
         dest=/etc/yum.repos.d/cloudera-cdh5.repo backup=no
         owner=root group=root mode=0644
   when: inventory_hostname in groups.standalone
+
+- name: Install Nagios repo
+  tags: monitoring_engine_repo
+  copy: src=etc/yum.repos.d/nagios.repo
+        dest=/etc/yum.repos.d/nagios.repo backup=no
+        owner=root group=root mode=0644
+  when: inventory_hostname in groups.monitoring_engine


### PR DESCRIPTION
The goal of this PR is to add support for the deployment of the monitoring engines (Nagios) for each tenant.

- [x] Nagios and sub-components installation (nagios, ncg, msg)
- [x] Default configuration for NCG
- [x] Playbook to include the nessecary roles