### PR TITLE
ARGO-365 Fix in consumer configuration template

### DIFF
--- a/roles/consumer/templates/consumer.conf.j2
+++ b/roles/consumer/templates/consumer.conf.j2
@@ -37,5 +37,5 @@ UseSSL = False
 
 [Output]
 Directory = /var/lib/argo-{{ item.key | lower }}-consumer
-Filename = argo-consumer_log_%s.avro
-ErrorFilename = argo-consumer_error_log_%s.avro
+Filename = argo-consumer_log_DATE.avro
+ErrorFilename = argo-consumer_error_log_DATE.avro


### PR DESCRIPTION
# Description

After the latest consumer package update a change needs to be applied in the [configuration template][ref1] used by Ansible. This PR fixes this. 

[ref1]: https://github.com/ARGOeu/argo-egi-consumer/blob/devel/argo-egi-consumer.spec#L67