### PR TITLE
Consumer: HADOOP configuration files added with private redirection to private repo

### DIFF
--- a/roles/consumer/files/ar-compute/EGI_JOB_EGI-CLOUDMON-Critical_ap.json
+++ b/roles/consumer/files/ar-compute/EGI_JOB_EGI-CLOUDMON-Critical_ap.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_JOB_EGI-CLOUDMON-Critical_ap.json" %}

--- a/roles/consumer/files/ar-compute/EGI_JOB_EGI-CLOUDMON-Critical_cfg.json
+++ b/roles/consumer/files/ar-compute/EGI_JOB_EGI-CLOUDMON-Critical_cfg.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_JOB_EGI-CLOUDMON-Critical_cfg.json" %}

--- a/roles/consumer/files/ar-compute/EGI_JOB_EGI-OPS-MONITOR-Critical_ap.json
+++ b/roles/consumer/files/ar-compute/EGI_JOB_EGI-OPS-MONITOR-Critical_ap.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_JOB_EGI-OPS-MONITOR-Critical_ap.json" %}

--- a/roles/consumer/files/ar-compute/EGI_JOB_EGI-OPS-MONITOR-Critical_cfg.json
+++ b/roles/consumer/files/ar-compute/EGI_JOB_EGI-OPS-MONITOR-Critical_cfg.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_JOB_EGI-OPS-MONITOR-Critical_cfg.json" %}

--- a/roles/consumer/files/ar-compute/EGI_JOB_EGI-ROC-Critical_ap.json
+++ b/roles/consumer/files/ar-compute/EGI_JOB_EGI-ROC-Critical_ap.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_JOB_EGI-ROC-Critical_ap.json" %}

--- a/roles/consumer/files/ar-compute/EGI_JOB_EGI-ROC-Critical_cfg.json
+++ b/roles/consumer/files/ar-compute/EGI_JOB_EGI-ROC-Critical_cfg.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_JOB_EGI-ROC-Critical_cfg.json" %}

--- a/roles/consumer/files/ar-compute/EGI_db_conf.json
+++ b/roles/consumer/files/ar-compute/EGI_db_conf.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_db_conf.json" %}

--- a/roles/consumer/files/ar-compute/EGI_ops.json
+++ b/roles/consumer/files/ar-compute/EGI_ops.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EGI_ops.json" %}

--- a/roles/consumer/files/ar-compute/EUDAT_JOB_ServiceGroups_ap.json
+++ b/roles/consumer/files/ar-compute/EUDAT_JOB_ServiceGroups_ap.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EUDAT_JOB_ServiceGroups_ap.json" %}

--- a/roles/consumer/files/ar-compute/EUDAT_JOB_ServiceGroups_cfg.json
+++ b/roles/consumer/files/ar-compute/EUDAT_JOB_ServiceGroups_cfg.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EUDAT_JOB_ServiceGroups_cfg.json" %}

--- a/roles/consumer/files/ar-compute/EUDAT_db_conf.json
+++ b/roles/consumer/files/ar-compute/EUDAT_db_conf.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EUDAT_db_conf.json" %}

--- a/roles/consumer/files/ar-compute/EUDAT_ops.json
+++ b/roles/consumer/files/ar-compute/EUDAT_ops.json
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ar-compute/EUDAT_ops.json" %}

--- a/roles/consumer/files/core-site.xml
+++ b/roles/consumer/files/core-site.xml
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/core-site.xml" %}

--- a/roles/consumer/files/hadoop-env.sh
+++ b/roles/consumer/files/hadoop-env.sh
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/hadoop-env.sh" %}

--- a/roles/consumer/files/hdfs-site.xml
+++ b/roles/consumer/files/hdfs-site.xml
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/hdfs-site.xml" %}

--- a/roles/consumer/files/log4j.properties
+++ b/roles/consumer/files/log4j.properties
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/log4j.properties" %}

--- a/roles/consumer/files/mapred-site.xml
+++ b/roles/consumer/files/mapred-site.xml
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/mapred-site.xml" %}

--- a/roles/consumer/files/ssl-client.xml
+++ b/roles/consumer/files/ssl-client.xml
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/ssl-client.xml" %}

--- a/roles/consumer/files/topology.map
+++ b/roles/consumer/files/topology.map
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/topology.map" %}

--- a/roles/consumer/files/topology.py
+++ b/roles/consumer/files/topology.py
@@ -1,0 +1,1 @@
+{% include "private_files/" + ansible_fqdn + "/files/topology.py" %}

--- a/roles/consumer/tasks/main.yml
+++ b/roles/consumer/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Install pymongo fixed version
   tags: ar-packages
-  pip: name=pymongo state=present version=3.2.1
+  pip: name=pymongo state=present version=3.2.2
 
 - name: Install egi consumer package from ar project
   tags: 
@@ -92,6 +92,16 @@
             owner=root group=root mode=0644
             backup=yes
   with_dict: tenants
+  
+- name: Configure global connectors
+  tags: 
+    - connectors_config
+    - connectors
+  template: src=global.conf.j2
+            dest=/etc/argo-egi-connectors/global.conf
+            owner=root group=root mode=0644
+            backup=yes
+  with_dict: tenants
 
 - name: POEM configuration
   tags:
@@ -99,15 +109,6 @@
     - poem_config
   template: src=poem-connector.conf.j2
             dest=/etc/argo-egi-connectors/poem-connector.conf
-            owner=root group=root mode=0644
-            backup=yes
-
-- name: connectors Global configuration
-  tags:
-    - connectors_config
-    - connectors
-  template: src=global.conf.j2
-            dest=/etc/argo-egi-connectors/global.conf
             owner=root group=root mode=0644
             backup=yes
 
@@ -204,3 +205,34 @@
             dest=/etc/ar-data-retention/ar-data-retention.conf
             owner=root group=root mode=0644
 
+- name: Configure hadoop (mr) related parameter files
+  tags: hadoop_client_config
+  copy: src={{ item }}
+        dest=/etc/hadoop/conf/{{ item }} backup=yes
+        owner=root group=root mode=0644
+  with_items:
+    - core-site.xml
+    - hadoop-env.sh
+    - hdfs-site.xml
+    - log4j.properties
+    - mapred-site.xml
+    - ssl-client.xml
+    - topology.map
+    - topology.py
+
+- name: Configure pig related parameter
+  tags: pig_client_config
+  lineinfile: dest=/etc/pig/conf/pig.properties
+              regexp="^pig.logfile"
+              line="pig.logfile=/tmp/pig-err.log"
+              state=present
+              backup=yes
+
+- name: Insert comment for pig related parameter
+  tags: pig_client_config
+  lineinfile: dest=/etc/pig/conf/pig.properties
+              regexp="^# File Parameter"
+              insertbefore="^pig.logfile"
+              line="# File Parameter for pig exception dump."
+              state=present
+              backup=yes


### PR DESCRIPTION
**Usage**:

 - Create a soft link in the public repo to private_files dir which is inside argo-ansible-deploy. The directory naming schema is private_files/ansible_fqdn/.
 - Include the private file eg. private_files/snf-xxxxx.vm.okeanos.grnet.gr/files/test.conf.j2 in the main task by creating another template in public repo like this: /argo-ansible/roles/consumer/files/test.conf.j2

{% include "private_files/" + ansible_fqdn + "/files/test.conf.j2" %}

Include that template inside ansible's main task 

Full example: https://github.com/grnet/argo-ansible-deploy/pull/24 

