### PR TITLE
ARGO-461 Add Task for initializing messaging_api users and keys

### DIFF
--- a/roles/ingestion_api/tasks/main.yml
+++ b/roles/ingestion_api/tasks/main.yml
@@ -2,6 +2,6 @@
   template: dest="/tmp/init_ingestion.js" owner=root group=root mode=640 src=init_ingestion.js.j2
   tags: ingestion_api
 
-- name: Run init_defaults.js script
+- name: Run init_ingestion.js script
   shell: mongo < /tmp/init_ingestion.js
   tags: messaging_api

--- a/roles/messaging_api/defaults/main.yml
+++ b/roles/messaging_api/defaults/main.yml
@@ -4,3 +4,15 @@ argo_msg_port: 443
 argo_msg_store_host: 'localhost'
 argo_msg_store_db: 'argo_msg'
 argo_msg_zookeeper_hosts: '["localhost:2181"]'
+
+messaging_api_users:
+  -  username: default_admin
+     project: ARGO
+     key: ADMINTOKEN
+     role: admin
+     email: admin@argo.example.foo
+  -  username: default_viewer
+     project: ARGO
+     key: VIEWERTOKEN
+     role: viewer
+     email: viewer@argo.example.foo

--- a/roles/messaging_api/tasks/main.yml
+++ b/roles/messaging_api/tasks/main.yml
@@ -9,13 +9,31 @@
   shell: setcap 'cap_net_bind_service=+ep' /var/www/argo-messaging/argo-messaging
   tags: messaging_api
 
-- name: Move init_defaults.js script
-  template: dest="/tmp/init_defaults.js" owner=root group=root mode=640 src=init_defaults.js.j2
-  tags: messaging_api
 
-- name: Run init_defaults.js script
-  shell: mongo < /tmp/init_defaults.js
-  tags: messaging_api
+- name: Move init_roles.js script
+  template: dest="/tmp/init_roles.js" owner=root group=root mode=640 src=init_roles.js.j2
+  tags:
+    - messaging_api
+    - init_roles
+
+- name: Run init_roles.js script
+  shell: mongo < /tmp/init_roles.js
+  tags:
+    - messaging_api
+    - init_roles
+
+- name: Move init_users.js script
+  template: dest="/tmp/init_users.js" owner=root group=root mode=640 src=init_users.js.j2
+  tags:
+    - messaging_api
+    - init_users
+
+- name: Run init_users.js script
+  shell: mongo < /tmp/init_users.js
+  tags:
+    - messaging_api
+    - init_users
+
 
 - name: Configure argo-messaging api
   template: src=config.json.j2

--- a/roles/messaging_api/templates/init_roles.js.j2
+++ b/roles/messaging_api/templates/init_roles.js.j2
@@ -12,9 +12,5 @@ db.roles.insert([{"resource" : "topics:list", "roles" : [ "admin", "viewer" ] },
 {"resource" : "subscriptions:show", "roles" : [ "admin","viwer" ] },
 {"resource" : "subscriptions:acknowledge", "roles" : [ "admin" ] },
 {"resource" : "subscriptions:show", "roles" : [ "admin" ] },
+{"resource" : "subscriptions:pull", "roles" : [ "admin" ] },
 {"resource" : "subscriptions:modifyPushConfig", "roles" : [ "admin" ] }])
-db.users.remove({"name":"default_admin"})
-db.users.remove({"name":"default_viewer"})
-db.users.insert([{"name" : "default_admin", "email" : "admin@localhost", "project" : "ARGO", "token" : "ADMINTOKEN", "roles" : [ "admin", "viewer" ] },
-{"name" : "default_viewer", "email" : "viewer@localhost", "project" : "ARGO", "token" : "VIEWERTOKEN", "roles" : [ "viewer" ] }
-])

--- a/roles/messaging_api/templates/init_users.js.j2
+++ b/roles/messaging_api/templates/init_users.js.j2
@@ -1,0 +1,22 @@
+// Open Database
+use argo_msg
+
+
+// Create tenants
+
+
+
+{%- if messaging_api_users is defined -%}
+
+{%- for user in messaging_api_users -%}
+
+
+// Create tenant admin user
+db.users.update({"name" : "{{user.username}}"},{ "name":"{{user.username}}","email" : "{{user.email}}", "project" : "{{user.project}}", "token" : "{{user.key}}", "roles" : ["{{user.role}}"]},{"upsert":"true"})
+
+
+
+{%- endfor -%}
+
+
+{%- endif -%}


### PR DESCRIPTION
Add task for initializing users for messaging_api 
Uses the following variable structure:

```
messaging_api_users:
  -  username: default_admin
     project: ARGO
     key: ADMINTOKEN
     role: admin
     email: admin@argo.example.foo
  -  username: default_viewer
     project: ARGO
     key: VIEWERTOKEN
     role: viewer
     email: viewer@argo.example.foo
```
- Add Missing subscriptions:pull action in roles 