### PR TITLE
Users: Removed  messages about deprecation. 

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -38,8 +38,8 @@
 - name: SSH keys
   authorized_key: user="{{item.0.username}}" key="{{item.1}}"
   with_subelements:
-    - users
-    - ssh_key
+    - "{{users}}"
+    - "{{ssh_key}}"
   tags: ['users','configuration']
 
 - name: Deleted user removal


### PR DESCRIPTION
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax