### PR TITLE
ARGO-524 - Timezone module is not available in the ansible version we use

### DIFF
--- a/roles/timezone/tasks/main.yml
+++ b/roles/timezone/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
-- name: Set timezone
-  timezone: name=Europe/Athens
-  tags: timezone
+- name: Change timezone to Europe/Athens
+  command: timedatectl set-timezone Europe/Athens
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'


### PR DESCRIPTION
Updated the timezone role from timezone to command to match the current ansible version. 