### PR TITLE
[ARGO-527] - The ansible script does not properly allow traffic for https

### DIFF
--- a/roles/firewall/tasks/centos7.yml
+++ b/roles/firewall/tasks/centos7.yml
@@ -4,3 +4,7 @@
   command: firewall-cmd --zone=public --add-service={{item}} --permanent
   with_items: services
   when: services is defined
+
+- name: Restart firewalld
+  command: systemctl restart firewalld
+  


### PR DESCRIPTION
The ansible script does not restart the firewall and thus https is filtered although the configuration is there. I updated the ansible script to restart firewall for centos7. 