### PR TITLE
[ARGO-526]: The argo-messaging service is not started correctly from …

### DIFF
--- a/roles/has_certificate/tasks/main.yml
+++ b/roles/has_certificate/tasks/main.yml
@@ -21,13 +21,14 @@
   file: state=link
         src={{ cert_path }}
         path=/etc/pki/tls/certs/localhost.crt
-  when: inventory_hostname in groups.standalone 
+  when: (inventory_hostname in groups.standalone or inventory_hostname in groups.messaging)
 
 - name: Create softlink (to key) for API
   file: state=link
         src={{ key_path }}
         path=/etc/pki/tls/private/localhost.key
-  when: inventory_hostname in groups.standalone 
+  when: (inventory_hostname in groups.standalone or inventory_hostname in groups.messaging)
+
 
 - name: Create p12 key for web ui
   command: openssl pkcs12 -export -in hostcert.pem -inkey hostkey.pem -password pass:{{ keystore_password }} -out server.p12


### PR DESCRIPTION
…the ansible script. It was due to wrong configuration to has_certificate role