### PR TITLE
AMS: mongo: add consumer role to subscription acknowledge action

### DIFF
--- a/roles/messaging_api/templates/init_roles.js.j2
+++ b/roles/messaging_api/templates/init_roles.js.j2
@@ -24,7 +24,7 @@ db.roles.insert([
 {"resource" : "subscriptions:delete", "roles" : ["project_admin" ] },
 {"resource" : "subscriptions:list", "roles" : [ "project_admin" ] },
 {"resource" : "subscriptions:show", "roles" : [ "project_admin" ] },
-{"resource" : "subscriptions:acknowledge", "roles" : [ "project_admin" ] },
+{"resource" : "subscriptions:acknowledge", "roles" : [ "project_admin", "consumer" ] },
 {"resource" : "subscriptions:show", "roles" : [ "project_admin" ] },
 {"resource" : "subscriptions:pull", "roles" : [ "project_admin","consumer" ] },
 {"resource" : "subscriptions:acl", "roles" : [ "project_admin" ] },


### PR DESCRIPTION
### Issue
AMS: Users with 'consumer' role should be able to call subscription:acknowledge

### Fix
Add 'consumer' role to 'subscription:acknowledge' resource in init_roles template script
