### PR TITLE
ARGO-876: Create java.env to host JAVA_OPTIONS

### DIFF
--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -68,6 +68,11 @@
     - restart zookeeper
   tags: zookeeper_config
 
+- name: Setup java.env
+  template: dest="{{zookeeper_conf_dir}}/java.env" src=java.env.j2
+  notify:
+    - restart zookeeper
+  tags: zookeeper_config
 
 - name: Create log_dir
   file: path={{zookeeper_log_dir}} state=directory owner=zookeeper group=zookeeper mode=755

--- a/roles/zookeeper/templates/java.env.j2
+++ b/roles/zookeeper/templates/java.env.j2
@@ -1,0 +1,7 @@
+export ZOO_LOG_DIR={{zookeeper_log_dir}}
+
+{% if zookeeper_heap_opt is defined %}
+export _JAVA_OPTIONS="{{ zookeeper_heap_opt }}"
+{% endif %}
+
+export _JAVA_OPTIONS=-Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
Zookeeper use of java.env at conf folder to export and enable java options