### PR TITLE
Add kafka java parameter for ipv4 interface preference

### DIFF
--- a/roles/kafka/templates/kafka.service.j2
+++ b/roles/kafka/templates/kafka.service.j2
@@ -9,6 +9,7 @@ Group=kafka
 LimitNOFILE=32768
 Restart=on-failure
 Environment="KAFKA_HEAP_OPTS={{ kafka_heap_opts }}"
+Environment="KAFKA_OPTS=-Djava.net.preferIPv4Stack=true"
 ExecStart=/opt/kafka_{{ kafka_scala_version }}-{{ kafka_version }}/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]


### PR DESCRIPTION
Use 'KAFKA_OPTS' env variable for extra java options during kafka start-up
Use -Djava.net.preferIpv4Stack for prefering ipv4 sockets in systems where ipv6 is available

Declare the option in kafka.service file as an additional Enviroment parameter