### PR TITLE
[kafka] - added replication factor dynamically

### DIFF
--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -12,7 +12,6 @@ kafka_data_dir: /var/lib/kafka
 kafka_log_dir:  /var/log/kafka
 kafka_conf_dir: "/etc/kafka"
 zookeeper_hosts: "{{ansible_fqdn}}:2181"
-replication_factor: 1
 
 kafka_num_network_threads: 2
 kafka_num_io_threads: 2

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -111,6 +111,10 @@ zookeeper.connect={{zookeeper_hosts}}
 zookeeper.connection.timeout.ms={{zookeeper_connection_timeout_ms}}
 
 ############################# Replication #############################
-
 # default replication factors for automatically created topics
-default.replication.factor={{replication_factor}}
+
+{% if ( groups['kafka'] | length ) >= 3 -%}
+default.replication.factor=3
+{%- else -%}
+default.replication.factor=1    
+{% endif %}


### PR DESCRIPTION
a) Added a new  kafka group to inventory.
b) in server.properties i count the number of servers in kafka group and if it is > 3 then replication factor is 3, otherwise it is set to 1.