### PR TITLE
Refactor has_certificate for haproxy and argo-messaging cert placement

### DIFF
--- a/roles/has_certificate/defaults/main.yml
+++ b/roles/has_certificate/defaults/main.yml
@@ -3,3 +3,5 @@
 cert_dir: /etc/grid-security/
 cert_path: /etc/grid-security/hostcert.pem
 key_path: /etc/grid-security/hostkey.pem
+
+argo_msg_path: '/var/www/argo-messaging/'

--- a/roles/has_certificate/tasks/main.yml
+++ b/roles/has_certificate/tasks/main.yml
@@ -29,6 +29,18 @@
         path=/etc/pki/tls/private/localhost.key
   when: (inventory_hostname in groups.standalone) or (inventory_hostname in groups.messaging)
 
+- name: ensure haproxy group
+  group:
+    name: haproxy
+    state: present
+  when: (inventory_hostname in groups.haproxy)
+
+- name: ensure haproxy user
+  user:
+    name: haproxy
+    group: haproxy
+  when: (inventory_hostname in groups.haproxy)
+
 - name: Copy host x509 certificate onto host
   tags: msg_certificate
   copy: src=private_files/{{ inventory_hostname }}/{{ inventory_hostname }}.pem
@@ -45,7 +57,7 @@
 
 - name: Bundle x509 crt and key in a single pem file
   tags: msg_certificate
-  shell: cat /{{ cert_dir }}/{{ inventory_hostname }}.pem /{{cert_dir}}/{{inventory_hostname}}.key > /{{cert_dir}}/{{inventory_hostname}}.crt 
+  shell: cat /{{ cert_dir }}/{{ inventory_hostname }}.pem /{{cert_dir}}/{{inventory_hostname}}.key > /{{cert_dir}}/{{inventory_hostname}}.crt
   when: (inventory_hostname in groups.haproxy)
 
 


### PR DESCRIPTION
- Ensure haproxy user:group exists before chmod certificate
- Ensure default path `/var/www/argo-messaging/` is defined when creating link files to certificates for argo-messaging