### PR TITLE
ARGO-1025 Firewall rules for accessing ams kafka service

### DIFF
--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -4,6 +4,67 @@
 # https://github.com/hpcloud-mon/ansible-kafka
 # https://github.com/hpcloud-mon/ansible-zookeeper
 
+# Firewall Rules related to opening kafka to public ip for a specific source
+
+- name: Create firewall new zones
+  command: firewall-cmd --permanent --new-zone="{{item}}"
+  with_items: "{{firewall_zones}}"
+  notify: reload firewall
+  when: firewall_zones is defined
+  tags: firewall
+  ignore_errors: yes
+
+- name: Create firewall new services
+  command: firewall-cmd --permanent --new-service="{{item.name}}"
+  with_items: "{{firewall_services}}"
+  notify: reload firewall
+  when: firewall_services is defined
+  tags: firewall
+  ignore_errors: yes
+
+- name:  Add port to services
+  command: firewall-cmd --permanent --service="{{item.name}}" --add-port={{item.port}}
+  with_items: "{{firewall_services}}"
+  notify: reload firewall
+  when: firewall_services is defined
+  tags: firewall
+  ignore_errors: yes
+
+- name: Firewall add services to zones
+  firewalld:
+    zone: "{{item.zone}}"
+    service: "{{item.service}}"
+    permanent: true
+    state: enabled
+  with_items: "{{firewall_services_zones}}"
+  when: firewall_services_zones is defined
+  tags: firewall
+  notify: reload firewall
+
+- name: Add sources to zones
+  firewalld:
+    zone: "{{item.zone}}"
+    source: "{{item.source}}"
+    permanent: true
+    state: enabled
+  with_items: "{{firewall_sources}}"
+  when: firewall_sources is defined
+  tags: firewall
+  notify: reload firewall
+
+- name: Add interfaces to zones
+  firewalld:
+    zone: "{{item.zone}}"
+    interface: "{{item.interface}}"
+    permanent: true
+    state: enabled
+  with_items: "{{firewall_interfaces}}"
+  when: firewall_interfaces is defined
+  tags: firewall
+  notify: reload firewall
+
+# Deploy kafka
+
 - name: Install OpenJDK
   yum: name=java-1.7.0-openjdk state=present
   tags: kafka_install
@@ -50,11 +111,11 @@
 - name: Open firewalld port 9092 for zookeeper
   command: firewall-cmd --zone=public --add-port=9092/tcp --permanent
   tags: kafka_config
-  
-- name: restart firewalld 
+
+- name: restart firewalld
   command: service firewalld restart
   tags: kafka_config
-  
+
 - name: Create log_dir
   file: path={{kafka_log_dir}} state=directory owner=kafka group=kafka mode=755
   tags: kafka_config
@@ -80,7 +141,7 @@
 - name: create server.properties
   template: dest="{{kafka_conf_dir}}/server.properties" owner=kafka group=kafka mode=640 src=server.properties.j2
   tags: kafka_config
-  
+
 - name: create meta.properties
   template: dest="{{kafka_data_dir}}/meta.properties" owner=kafka group=kafka mode=640 src=meta.properties.j2
   notify:


### PR DESCRIPTION
Add same firewall rule command structure as in web_api_v2 into kafka role so as not to disturb previous roles used in playbook
- Ability to specify zones
- Ability to specify services
- Ability to specify sources
- Ability to add services to zones, and interfaces to zones
