### PR TITLE
Update haproxy cfg bind for both ipv4/6

### DIFF
--- a/roles/haproxy/templates/haproxy_template.cfg.j2
+++ b/roles/haproxy/templates/haproxy_template.cfg.j2
@@ -79,7 +79,7 @@ defaults
 # Statistics Interface Setup
 
 listen stats
-        bind *:9000 ssl crt {{cert_dir}}/{{inventory_hostname}}.crt no-sslv3
+        bind :::9000 ssl crt {{cert_dir}}/{{inventory_hostname}}.crt no-sslv3
         mode            http
         log             global
         maxconn 10
@@ -101,8 +101,8 @@ listen stats
 
 #frontend
 frontend  {{haproxy_frontend}}
-   bind *:{{haproxy_port_bind_ssl}} ssl crt {{cert_dir}}/{{inventory_hostname}}.crt no-sslv3
-   bind *:{{haproxy_port_bind}}
+   bind :::{{haproxy_port_bind_ssl}} ssl crt {{cert_dir}}/{{inventory_hostname}}.crt no-sslv3
+   bind :::{{haproxy_port_bind}}
    redirect scheme https if !{ ssl_fc }
    http-response set-header Strict-Transport-Security max-age=31536000
    option http-server-close


### PR DESCRIPTION
In haproxy.cfg, change bind statements from `*:port --> :::port` (for supporting both ipv6 and ipv4)