### PR TITLE
Add authn redirect to haproxy cfg template

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -11,3 +11,5 @@ haproxy_maxconn: 20
 haproxy_stats_port: 9000
 haproxy_port_bind_ssl: 443
 haproxy_port_bind: 80
+haproxy_authn_host: authn.foo
+haproxy_authn_port: 8080

--- a/roles/haproxy/templates/haproxy_template.cfg.j2
+++ b/roles/haproxy/templates/haproxy_template.cfg.j2
@@ -109,11 +109,25 @@ frontend  {{haproxy_frontend}}
    option forwardfor
    reqadd X-Forwarded-Proto:\ https
    reqadd X-Forwarded-Port:\ 443
+
+   # choose other backend if request path begins with authn
+   acl    is_authn     path_beg /authn
+   use_backend authn_backend if is_authn
+
    default_backend {{haproxy_default_backend}}
 
 
 #---------------------------------------------------------------------
-# round robin balancing between the various backends
+# authn backend - authn service runs usually in 8080
+#---------------------------------------------------------------------
+backend authn_backend
+	#add regexp to remove /authn from path
+	reqrep ^([^\ ]*\ /)authn[/]?(.*)     \1\2
+	server authn1  {{haproxy_authn_host}}:{{haproxy_authn_port}} ssl check port {{haproxy_authn_port}}
+
+
+#---------------------------------------------------------------------
+# round robin balancing between the various msg backends
 #---------------------------------------------------------------------
 
 


### PR DESCRIPTION
Add section for using authn backend in haproxy
- add configurable `authn_host` and `authn_port` in ansible host vars
- declare authn backend to haproxy.cfg.template
- add rule for using authn backend (when url path begins with `/authn`)
