### PR TITLE
AO-364 Fixes in argo-web-api v2 deployment

### DIFF
--- a/roles/repos/tasks/main.yml
+++ b/roles/repos/tasks/main.yml
@@ -46,7 +46,7 @@
   copy: src=etc/yum.repos.d/mongodb-org-3.2.repo
         dest=/etc/yum.repos.d/mongodb-org-3.2.repo backup=no
         owner=root group=root mode=0644
-  when: (inventory_hostname in groups.messaging or inventory_hostname in groups.alerta) and ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
+  when: (inventory_hostname in groups.messaging or inventory_hostname in groups.alerta or inventory_hostname in groups.webapi_v2) and ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
 
 
 - name: Install EGI-trustanchors repository definitions

--- a/roles/webapi_v2/tasks/deploy.yml
+++ b/roles/webapi_v2/tasks/deploy.yml
@@ -1,5 +1,4 @@
 ---
-
 # Set timezone
 - name: Set timezone to Europe/Athens
   timezone:
@@ -11,7 +10,6 @@
   command: firewall-cmd --permanent --new-zone="{{item}}"
   with_items: "{{firewall_zones}}"
   notify: reload firewall
-  when: firewall_zones is defined
   tags: firewall
   ignore_errors: yes
 
@@ -19,7 +17,6 @@
   command: firewall-cmd --permanent --new-service="{{item.name}}"
   with_items: "{{firewall_services}}"
   notify: reload firewall
-  when: firewall_services is defined
   tags: firewall
   ignore_errors: yes
 
@@ -27,7 +24,6 @@
   command: firewall-cmd --permanent --service="{{item.name}}" --add-port={{item.port}}
   with_items: "{{firewall_services}}"
   notify: reload firewall
-  when: firewall_services is defined
   tags: firewall
   ignore_errors: yes
 
@@ -38,7 +34,6 @@
     permanent: true
     state: enabled
   with_items: "{{firewall_services_zones}}"
-  when: firewall_services_zones is defined
   tags: firewall
   notify: reload firewall
 
@@ -49,7 +44,6 @@
     permanent: true
     state: enabled
   with_items: "{{firewall_sources}}"
-  when: firewall_sources is defined
   tags: firewall
   notify: reload firewall
 
@@ -60,7 +54,6 @@
     permanent: true
     state: enabled
   with_items: "{{firewall_interfaces}}"
-  when: firewall_interfaces is defined
   tags: firewall
   notify: reload firewall
 
@@ -153,20 +146,28 @@
 
 - name: Copy localhost key
   copy:
-    src: /etc/pki/tls/private/localhost.key
-    dest: /var/www/argo-web-api/certs
+    src: /etc/grid-security/hostkey.pem
+    dest: /var/www/argo-web-api/certs/localhost.key
     owner: argo-web-api
     group: argo-web-api
+    remote_src: true
   tags: api
 
 - name: Copy localhost cert
   copy:
-    src: /etc/pki/tls/certs/localhost.crt
-    dest: /var/www/argo-web-api/certs
+    src: /etc/grid-security/hostcert.pem
+    dest: /var/www/argo-web-api/certs/localhost.crt
+    owner: argo-web-api
+    group: argo-web-api
+    remote_src: true
+  tags: api
+
+- name: set argo-web-api binary to argo-web-api users
+  file:
+    path: /var/www/argo-web-api/argo-web-api
     owner: argo-web-api
     group: argo-web-api
   tags: api
-
 
 - name: allow bind port 443
   shell: setcap 'cap_net_bind_service=+ep' /var/www/argo-web-api/argo-web-api
@@ -175,7 +176,7 @@
 - name: Configure argo-web-api
   template: src=argo-web-api.conf.j2
             dest=/etc/argo-web-api.conf backup=yes
-            owner=root group=root mode=0644
+            owner=argo-web-api group=argo-web-api mode=0644
   notify: restart argo-web-api service
   tags: api
 

--- a/roles/webapi_v2/templates/init_users.js.j2
+++ b/roles/webapi_v2/templates/init_users.js.j2
@@ -10,7 +10,7 @@ use {{argo_core}}
 
 ;
 
-db.authentication.update("name" : "{{user.name}}"},{"name":"{{user.name}}","email" : "{{user.email}}", "api_key" : "{{user.api_key}}" },{"upsert":"true"})
+db.authentication.update({"name" : "{{user.name}}"},{"name":"{{user.name}}","email" : "{{user.email}}", "api_key" : "{{user.api_key}}" },{"upsert":"true"})
 
 
 {%- endfor -%}

--- a/webapi_v2_deploy.yml
+++ b/webapi_v2_deploy.yml
@@ -3,6 +3,7 @@
 - hosts: webapi_v2
   sudo: true
   roles:
+    - { role: selinux, tags: selinux_disable}
     - { role: basic_utils }
     - { role: repos }
     - { role: has_certificate, tags: has_certificate }


### PR DESCRIPTION
- Refactor repos role to install mongodb 3.2 when api is deployed
- Remove `when var is defined rules` from firewall tasks and use empty list instead (when variables should not be defined)
- Refactor tasks that move certificates for argo-web-api service
- Refactor permissions in folders used by argo-web-api service
- Fix typo in init users script for mongodb
- Add selinux role