### PR TITLE
Update firewall role

### DIFF
--- a/roles/commons/README.md
+++ b/roles/commons/README.md
@@ -1,23 +1,32 @@
-Role Name
+Commons
 =========
 
-A brief description of the role goes here.
+Commons role deploys some common stuff on all nodes
+
+Consists of the following task:
+- Firewall
+
+Firewall task manages the firewall rules on the node. It uses a combination of ansible command and firewalld modules.
+Sets desired interfaces to be unmanaged by NetworkManager and then resets FirewallD setting to the initial
+Centos 7 deployment configuration (only public zone with ssh and dchp6-client). Then according to the declared firewall_ prefixed host_vars generates new zones, services, interfaces and services to zones mappings.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should
-be mentioned here. For instance, if the role uses the EC2 module, it may be a
-good idea to mention in this section that the boto package is required.
+Selinux should be turned off
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including
-any variables that are in defaults/main.yml, vars/main.yml, and any variables
-that can/should be set via parameters to the role. Any variables that are read
-from other roles and/or the global scope (ie. hostvars, group vars, etc.) should
-be mentioned here as well.
+Firewall-related:
+
+- firewall_unmanaged_nics: a list of interfaces to be unmanaged by NetworkManager
+- firewall_sources: a list of sources to be created
+- firewall_interfaces: a list of interfaces to be added to zones (items: {"interface":"ethX", "zone":"zone to map to"})
+- firewall_zones: a list of zones to be created
+- firewall_services: a list of services to be created (items: {"name": "service name", "port": "port_num/tcp"})
+- firewall_services_zones: a list that maps services to zones (items: {"service":"service name", "zone": "zone to map to"})
+
 
 Dependencies
 ------------
@@ -39,10 +48,9 @@ passed in as parameters) is always nice for users too:
 License
 -------
 
-BSD
+Apache 2.0
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a
-website (HTML is not allowed).
+GRNET

--- a/roles/commons/defaults/main.yml
+++ b/roles/commons/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for commons
 
 # firewall default vars
+firewall_unmanaged_nics: []
 firewall_sources: []
 firewall_interfaces: []
 firewall_zones: []

--- a/roles/commons/handlers/main.yml
+++ b/roles/commons/handlers/main.yml
@@ -10,3 +10,8 @@
 
 - name: reload firewall
   command: "firewall-cmd --reload"
+
+- name: restart firewall
+  service:
+    name: firewalld
+    state: restarted

--- a/roles/commons/tasks/firewall.yml
+++ b/roles/commons/tasks/firewall.yml
@@ -1,24 +1,54 @@
 ---
 
+- name: Set eth devices unmanaged by network manager
+  command: "nmcli dev set {{item}} managed no"
+  with_items: "{{firewall_unmanaged_interfaces}}"
+  tags: firewall
+
+- name: Clear firewall state
+  command: "rm -f /etc/firewalld/{{item}}/*"
+  with_items:
+    - services
+    - zones
+    - helpers
+    - icmptypes
+    - ipsets
+  tags: firewall
+  args:
+    warn: false
+
+- name: Add default services to public zone
+  firewalld:
+    zone: public
+    service: "{{item}}"
+    permanent: true
+    state: enabled
+  with_items:
+    - ssh
+    - dhcpv6-client
+  tags: firewall
+  notify: restart firewall
+
+- meta: flush_handlers
 
 - name: Create firewall new zones
   command: firewall-cmd --permanent --new-zone="{{item}}"
   with_items: "{{firewall_zones}}"
-  notify: reload firewall
+  notify: restart firewall
   tags: firewall
   ignore_errors: true
 
 - name: Create firewall new services
   command: firewall-cmd --permanent --new-service="{{item.name}}"
   with_items: "{{firewall_services}}"
-  notify: reload firewall
+  notify: restart firewall
   tags: firewall
   ignore_errors: true
 
 - name: Add port to services
   command: firewall-cmd --permanent --service="{{item.name}}" --add-port={{item.port}}
   with_items: "{{firewall_services}}"
-  notify: reload firewall
+  notify: restart firewall
   tags: firewall
   ignore_errors: true
 
@@ -30,7 +60,7 @@
     state: enabled
   with_items: "{{firewall_services_zones}}"
   tags: firewall
-  notify: reload firewall
+  notify: restart firewall
 
 - name: Add sources to zones
   firewalld:
@@ -40,7 +70,7 @@
     state: enabled
   with_items: "{{firewall_sources}}"
   tags: firewall
-  notify: reload firewall
+  notify: restart firewall
 
 - name: Add interfaces to zones
   firewalld:
@@ -50,4 +80,4 @@
     state: enabled
   with_items: "{{firewall_interfaces}}"
   tags: firewall
-  notify: reload firewall
+  notify: restart firewall


### PR DESCRIPTION
- Firewall role now declares unmanaged interfaces from NetworkManager
- Firewall role can now reset FirewallD to initial Centos7 deployment settings
- Add Firewalld service restart handler