### PR TITLE
Add kafka role

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -28,3 +28,8 @@
   become: yes
   roles:
     - { role: zookeeper, tags: zookeeper_install }
+
+- hosts: kafka
+  become: yes
+  roles:
+    - { role: kafka, tags: kafka_install }

--- a/roles/commons/files/etc/yum.repos.d/cloudera-kafka.repo
+++ b/roles/commons/files/etc/yum.repos.d/cloudera-kafka.repo
@@ -1,0 +1,6 @@
+[cloudera-kafka]
+# Packages for Cloudera's Distribution for kafka, Version 1, on RedHat	or CentOS 7 x86_64
+name=Cloudera's Distribution for kafka, Version 1
+baseurl=http://archive.cloudera.com/kafka/redhat/7/x86_64/kafka/1/
+gpgkey = http://archive.cloudera.com/kafka/redhat/7/x86_64/kafka/RPM-GPG-KEY-cloudera
+gpgcheck = 1

--- a/roles/kafka/.yamllint
+++ b/roles/kafka/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/roles/kafka/README.md
+++ b/roles/kafka/README.md
@@ -1,0 +1,47 @@
+Kafka
+=========
+
+This role installs a kafka cluster for 1...N nodes (preferably keep N odd)
+
+Requirements
+------------
+
+This role needs to be executed after commons and zookeeper roles (or a zookeeper 
+cluster should be already available)
+
+Role Variables
+--------------
+
+kafka_broker_id: an integer signified the broker and should be unique for each node
+kafka_zookeeper_connect: a list of zookeeper nodes (host:port) for the broker to connect to
+
+Dependencies
+------------
+
+commons-role-vars:
+  repos_cloudera_kafka: true
+  
+  firewall_services:
+    - name: kafka
+      port: 9092/tcp
+ 
+  firewall_services_zones:
+    - service: kafka
+      zone: internal
+  
+
+Example Playbook
+----------------
+
+    - hosts: kafka
+      roles:
+         - { role: kafka, tags: kafka_install }
+
+License
+-------
+
+Apache 2
+
+Author Information
+------------------
+GRNET

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for kafka
+kafka_broker_id: 0
+kafka_zookeeper_connect: localhost:2181

--- a/roles/kafka/handlers/main.yml
+++ b/roles/kafka/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# handlers file for kafka
+
+- name: restart kafka
+  service:
+    name: kafka-server
+    state: restarted

--- a/roles/kafka/meta/main.yml
+++ b/roles/kafka/meta/main.yml
@@ -1,0 +1,58 @@
+---
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.

--- a/roles/kafka/molecule/default/Dockerfile.j2
+++ b/roles/kafka/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/kafka/molecule/default/INSTALL.rst
+++ b/roles/kafka/molecule/default/INSTALL.rst
@@ -1,0 +1,26 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+Ansible < 2.6
+
+.. code-block:: bash
+
+    $ sudo pip install docker-py
+
+Ansible >= 2.6
+
+.. code-block:: bash
+
+    $ sudo pip install docker

--- a/roles/kafka/molecule/default/molecule.yml
+++ b/roles/kafka/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    image: centos:7
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/roles/kafka/molecule/default/playbook.yml
+++ b/roles/kafka/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: kafka

--- a/roles/kafka/molecule/default/tests/test_default.py
+++ b/roles/kafka/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# tasks file for kafka
+
+- name: Install kafka package
+  yum:
+    name: "{{item}}"
+    state: present
+    enablerepo: cloudera-kafka
+  loop:
+    - kafka
+    - kafka-server
+  tags: kafka_install
+
+
+- name: Update kafka configuration
+  template:
+    src: server.properties.j2
+    dest: /etc/kafka/conf/server.properties
+    owner: kafka
+    group: kafka
+    mode: 0644
+  notify: restart kafka
+  tags: kafka_install
+
+- name: Start kafka service
+  service:
+    name: kafka-server
+    state: started
+    enabled: true
+  tags: kafka_install

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id={{kafka_broker_id}}
+
+############################# Socket Server Settings #############################
+
+# The port the socket server listens on
+port=9092
+
+# Hostname the broker will bind to. If not set, the server will bind to all interfaces
+#host.name=localhost
+
+# Hostname the broker will advertise to producers and consumers. If not set, it uses the
+# value for "host.name" if configured.  Otherwise, it will use the value returned from
+# java.net.InetAddress.getCanonicalHostName().
+#advertised.host.name=<hostname routable by clients>
+
+# The port to publish to ZooKeeper for clients to use. If this is not set,
+# it will publish the same port that the broker binds to.
+#advertised.port=<port accessible by clients>
+
+# The number of threads handling network requests
+num.network.threads=3
+
+# The number of threads doing disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma seperated list of directories under which to store log files
+log.dirs=/tmp/kafka-logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=1
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
+# segments don't drop below log.retention.bytes.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000
+
+# By default the log cleaner is disabled and the log retention policy will default to just delete segments after their retention expires.
+# If log.cleaner.enable=true is set the cleaner will be enabled and individual logs can then be marked for log compaction.
+log.cleaner.enable=false
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect={{kafka_zookeeper_connect}}
+
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=6000

--- a/roles/kafka/vars/main.yml
+++ b/roles/kafka/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for kafka


### PR DESCRIPTION
- Use cloudera kafka repo to install kafka through rpm 
- Needs an existing zookeeper cluster (or to be run after zookeeper role)
- depends on the following host_vars:
   repo_cloudera_kafka: true (must be enabled so as to get cloudera kafka repo when commons/repos task executes)
   kafka_broker_id: fill broker id (unique for each node)
   kafka_zookeeper_connect: list of zk hosts (`host1:2181,host2:2181,host3:2181`) to connect to
- apply linting
- update readme