### PR TITLE
Update ams roles for argo-api-authn and metrics-ui

### DIFF
--- a/roles/ams/templates/db_init_roles.js.j2
+++ b/roles/ams/templates/db_init_roles.js.j2
@@ -1,6 +1,8 @@
 use {{ams_store_db}}
 db.roles.drop()
 db.roles.insert([
+{"resource" : "ams:metrics", "roles": ["service_admin", "metrics_viewer"]},
+{"resource" : "users:byUUID", "roles" : [ "service_admin", "argo_api_authn"] },
 {"resource" : "users:byToken", "roles" : [ "service_admin" ] },
 {"resource" : "users:list", "roles" : [ "service_admin", "project_admin" ] },
 {"resource" : "users:show", "roles" : [ "service_admin", "project_admin" ] },


### PR DESCRIPTION
- Update initialization of ams roles in database:
 - make GET user by uuid accessible for `service_admin` and `argo_api_authn` roles
 - make GET metrics accessible for `service_admin` and `metrics_viewer` roles