### PR TITLE
Add replicated mongo setup

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -27,6 +27,7 @@
 - hosts: ams_store
   become: yes
   roles:
+    - { role: private_hosts }
     - { role: mongodb }
     - { role: ams, task: init_db, tags: ams_install }
 

--- a/roles/ams/tasks/deploy.yml
+++ b/roles/ams/tasks/deploy.yml
@@ -26,5 +26,5 @@
   notify: restart argo-messaging
 
 - name: Start argo-messaging service
-  service: name=argo-messaging state=started
+  service: name=argo-messaging state=started enabled=true
   tags: ams_install

--- a/roles/commons/defaults/main.yml
+++ b/roles/commons/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for commons
 
 # firewall default vars
-firewall_unmanaged_nics: []
+firewall_private_interfaces: []
 firewall_sources: []
 firewall_interfaces: []
 firewall_zones: []

--- a/roles/commons/tasks/firewall.yml
+++ b/roles/commons/tasks/firewall.yml
@@ -1,8 +1,14 @@
 ---
 
-- name: Set eth devices unmanaged by network manager
-  command: "nmcli dev set {{item}} managed no"
-  with_items: "{{firewall_unmanaged_interfaces}}"
+- name: Register private connection uuid
+  command: "nmcli -g GENERAL.CON-UUID  d show {{item}}"
+  loop: "{{firewall_private_interfaces}}"
+  register: firewall_private_uuids
+  tags: firewall
+
+- name: Set zone internal to connections on network managed private interfaces
+  command: "nmcli connection modify {{item.stdout}} connection.zone internal"
+  loop: "{{firewall_private_uuids.results}}"
   tags: firewall
 
 - name: Clear firewall state

--- a/roles/commons/tasks/repos.yml
+++ b/roles/commons/tasks/repos.yml
@@ -34,12 +34,19 @@
        state=present
   when: repo_umd
 
-- name: Install promoo repo
+- name: Install cloudera repo
   tags: repo_cloudera
   copy: src=etc/yum.repos.d/cloudera.repo
         dest=/etc/yum.repos.d/cloudera.repo backup=no
         owner=root group=root mode=0644
   when: repo_cloudera
+
+- name: Install cloudera-kafka repo
+  tags: repo_cloudera_kafka
+  copy: src=etc/yum.repos.d/cloudera-kafka.repo
+        dest=/etc/yum.repos.d/cloudera-kafka.repo backup=no
+        owner=root group=root mode=0644
+  when: repo_cloudera_kafka
 
 - name: Install promoo repo
   tags: repo_monbox

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -117,6 +117,7 @@ log.cleaner.enable=false
 # root directory for all kafka znodes.
 zookeeper.connect={% for host in groups[cluster_group] %}{{hostvars[host]['private']['hostname']}}:2181{% if not loop.last %},{% endif %}{% endfor %}
 
+auto.create.topics.enable=true
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms=6000

--- a/roles/mongodb/README.md
+++ b/roles/mongodb/README.md
@@ -8,6 +8,23 @@ Requirements
 
 You will need to have the repo `mongodb-org-3.2` on the host.
 
+Role Variables
+--------------
+mongo_bind_interfaces: 127.0.0.1 # A Comma separated list of ips(interfaces) mongo should bind to
+mongo_replicated: false # If set to true mongodb will be deployed in a replicated fashion
+
+Dependencies
+------------
+
+You need to specify the ansible inventory group that will consist your cluster
+- cluster_group: mongo_cluster
+
+You need for each host to set up the following variable for the private interface
+private:
+ - hostname: foo.host.priv  # private hostname alias  
+   ip: 192.168.0.1 # private hostname
+   id: 1  # private
+
 Example Playbook
 ----------------
 

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -3,3 +3,4 @@
 
 # Comma separated list of IPs mongo service should bind to
 mongo_bind_interfaces: 127.0.0.1
+mongo_replicated: false

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -10,24 +10,30 @@
   loop:
     - mongodb-org
     - mongodb-org-server
+    - git
+    
+- name: install motop
+  pip:
+    name: git+https://github.com/tart/motop.git
 
-- name: Bind mongod processes to one or more interfaces
-  lineinfile: >
-              dest=/etc/mongod.conf
-              regexp="\ \ bindIp"
-              line='  bindIp: {{ mongo_bind_interfaces }}'
-              state=present
-              backup=true
+- name: create mongo replicated folder
+  file:
+    path: /var/lib/mongo_repl
+    state: directory
+    owner: mongod
+    group: mongod
+  tags:
+    - mongo_install
+  notify: restart mongo
+  when: mongo_replicated == true
+
+- name: configure mongo
+  template: dest="/etc/mongod.conf" owner=mongod group=mongod mode=640 src=mongod.conf.j2
+  tags:
+    - mongo_install
   notify: restart mongo
 
-- name: Fix issue with mongo init script
-  lineinfile: >
-              dest=/etc/mongod.conf
-              regexp="\ \ pidFilePath"
-              line='  pidFilePath: /var/run/mongodb/mongod.pid'
-              state=present
-              backup=true
-  notify: restart mongo
+
 
 - name: Increase soft nproc limits
   copy:
@@ -44,3 +50,27 @@
     name: mongod
     enabled: true
     state: started
+
+- name: Move init replication script
+  template: dest="/tmp/db_init_rs.js" owner=root group=root mode=640 src=db_init_rs.js.j2
+  tags:
+    - mongo_replication
+  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+
+- name: Run init roles script
+  shell: mongo < /tmp/db_init_rs.js
+  tags:
+    - mongo_replication
+  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+
+- name: Move rs add members script
+  template: dest="/tmp/db_rs_members.js" owner=root group=root mode=640 src=db_rs_members.js.j2
+  tags:
+    - mongo_replication
+  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+
+- name: Run rs add members script
+  shell: mongo < /tmp/db_rs_members.js
+  tags:
+    - mongo_replication
+  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname

--- a/roles/mongodb/templates/db_init_rs.js.j2
+++ b/roles/mongodb/templates/db_init_rs.js.j2
@@ -1,0 +1,1 @@
+rs.initiate()

--- a/roles/mongodb/templates/db_rs_members.js.j2
+++ b/roles/mongodb/templates/db_rs_members.js.j2
@@ -1,0 +1,10 @@
+{%- for host in groups[cluster_group] -%}
+
+
+;
+
+rs.add("{{hostvars[host]['private']['hostname']}}:27017")
+
+
+
+{%- endfor -%}

--- a/roles/mongodb/templates/mongod.conf.j2
+++ b/roles/mongodb/templates/mongod.conf.j2
@@ -1,0 +1,50 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# Where and how to store data.
+storage:
+{% if mongo_replicated == true %}
+  dbPath: /var/lib/mongo_repl
+{% else %}
+  dbPath: /var/lib/mongo
+{% endif %}
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# how the process runs
+processManagement:
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: {{mongo_bind_interfaces}}
+
+#security:
+
+#operationProfiling:
+
+{% if mongo_replicated == true %}
+replication:
+   replSetName: rs0
+{% endif %}
+
+#sharding:
+
+## Enterprise-Only Options
+
+#auditLog:
+
+#snmp:

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -5,6 +5,11 @@
   yum: name=java-1.8.0-openjdk state=present
   tags: zookeeper_install
 
+- name: install zktop
+  pip:
+    name: zktop
+  tags: zookeeper_install
+
 - name: install zookeeper
   yum: name={{item}} state=present enablerepo=cloudera-cdh5
   with_items:


### PR DESCRIPTION
- Change mongo config from line-in-file edits to complete template
- Fix: ams service enabled to true
- Use mongo_replicated boolean as a replication conditional in deployments
- Use a different data folder (/var/lib/mongo_repl) when replication is enabled
- Use db_rs_init and db_rs_members javascript scripts to initiate replication set and group members
- add zktop, motop utilities
