### PR TITLE
AO-380 Configure internal zone in Network Manager

### DIFF
--- a/roles/commons/README.md
+++ b/roles/commons/README.md
@@ -20,7 +20,7 @@ Role Variables
 
 Firewall-related:
 
-- firewall_unmanaged_nics: a list of interfaces to be unmanaged by NetworkManager
+- firewall_private_interfaces: a list of interfaces to be in private networks
 - firewall_sources: a list of sources to be created
 - firewall_interfaces: a list of interfaces to be added to zones (items: {"interface":"ethX", "zone":"zone to map to"})
 - firewall_zones: a list of zones to be created

--- a/roles/commons/tasks/repos.yml
+++ b/roles/commons/tasks/repos.yml
@@ -41,7 +41,7 @@
         owner=root group=root mode=0644
   when: repo_cloudera
 
-- name: Install cloudera-kafka repo
+- name: Install cloudera kafka repo
   tags: repo_cloudera_kafka
   copy: src=etc/yum.repos.d/cloudera-kafka.repo
         dest=/etc/yum.repos.d/cloudera-kafka.repo backup=no


### PR DESCRIPTION
- Use nmcli to get connection uuids for declared private interfaces (declared as list in `{{firewall_private_interfaces}}` var)
- Register connection uuids to an ansible variable 
- Use ansible variable with connection uuids in nmcli to set connection.zone to internal
- update readme

Other Fixes:
- cloudera-kafka repo 
- use private_hosts role in ams_store group

