### PR TITLE
AO-405 Specify kafka log dirs

### DIFF
--- a/roles/kafka/README.md
+++ b/roles/kafka/README.md
@@ -12,7 +12,7 @@ cluster should be already available)
 Role Variables
 --------------
 
-None. See dependencies for other vars that must be set up
+kafka_log_dirs: comma separated list with folder for kafka to store data
 
 Dependencies
 ------------
@@ -25,7 +25,7 @@ You need for each host to set up the following variable for the private interfac
 private:
  - hostname: foo.host.priv  # private hostname alias  
    ip: 192.168.0.1 # private hostname
-   id: 1  # private 
+   id: 1  # private
 
 
 commons-role-vars:

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,1 +1,4 @@
 ---
+
+# Separated list of kafka folders
+kafka_log_dirs: /var/lib/kafka

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -55,7 +55,7 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma seperated list of directories under which to store log files
-log.dirs=/tmp/kafka-logs
+log.dirs={{kafka_log_dirs}}
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across


### PR DESCRIPTION
Use a variable to speciy kafka log directories. (Comma separated list of paths)
default value = '/var/lib/kafka'