### PR TITLE
DEVOPS-51 Fix the problem of restarting fail2ban service.

### DIFF
--- a/roles/commons/handlers/main.yml
+++ b/roles/commons/handlers/main.yml
@@ -2,11 +2,10 @@
 # handlers file for commons
 
 # handlers file for fail2ban
-- name: restart fail2ban (with service)
+- name: restart fail2ban
   service:
     name: fail2ban
     state: restarted
-  listen: "restart fail2ban"
 
 - name: reload firewall
   command: "firewall-cmd --reload"


### PR DESCRIPTION
There is a problem with the [**listen**](https://github.com/ARGOeu/argo-ansible/blob/ansible2.9/roles/commons/handlers/main.yml#L9) command, which creates continuous - unnecessary - reboots of the fail2ban service.

**EXPECTED RESULTS**
<details>
<summary> Output: </summary>

```
......................

TASK [commons : Install rsyslog gnutls] ***************************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [commons : Rsyslog conf file] ********************************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [commons : Rsyslog remote conf file] *************************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [commons : Restart the rsyslog service] **********************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [nickhammond.logrotate : nickhammond.logrotate | Install logrotate] ******************************************************************************************************************************************
ok: [centOS1-Knossos]

TASK [nickhammond.logrotate : nickhammond.logrotate | Setup logrotate.d scripts] **********************************************************************************************************************************
changed: [centOS1-Knossos] => (item={'name': 'nagios-log', 'path': '/var/log/nagios/nagios.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-access-log', 'path': '/var/log/httpd/access.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate'], 'scripts': {'postrotate': 'echo set up logrotate for httpd access.log'}})
changed: [centOS1-Knossos] => (item={'name': 'httpd-error-log', 'path': '/var/log/httpd/error.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-ssl-access-log', 'path': '/var/log/httpd/ssl_access_log.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-ssl-error-log', 'path': '/var/log/httpd/ssl_error_log.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-ssl-request-log', 'path': '/var/log/httpd/ssl_request_log.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})

RUNNING HANDLER [commons : restart fail2ban] **********************************************************************************************************************************************************************
changed: [centOS1-Knossos]

RUNNING HANDLER [commons : restart firewall] **********************************************************************************************************************************************************************
changed: [centOS1-Knossos]


```
</details>

---------------------------------------------------------------------------------

**ACTUAL RESULTS**
<details>
<summary> Output: </summary>

```
......................

TASK [commons : Install rsyslog gnutls] ***************************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [commons : Rsyslog conf file] ********************************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [commons : Rsyslog remote conf file] *************************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [commons : Restart the rsyslog service] **********************************************************************************************************************************************************************
changed: [centOS1-Knossos]

TASK [nickhammond.logrotate : nickhammond.logrotate | Install logrotate] ******************************************************************************************************************************************
ok: [centOS1-Knossos]

TASK [nickhammond.logrotate : nickhammond.logrotate | Setup logrotate.d scripts] **********************************************************************************************************************************
changed: [centOS1-Knossos] => (item={'name': 'nagios-log', 'path': '/var/log/nagios/nagios.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-access-log', 'path': '/var/log/httpd/access.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate'], 'scripts': {'postrotate': 'echo set up logrotate for httpd access.log'}})
changed: [centOS1-Knossos] => (item={'name': 'httpd-error-log', 'path': '/var/log/httpd/error.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-ssl-access-log', 'path': '/var/log/httpd/ssl_access_log.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-ssl-error-log', 'path': '/var/log/httpd/ssl_error_log.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})
changed: [centOS1-Knossos] => (item={'name': 'httpd-ssl-request-log', 'path': '/var/log/httpd/ssl_request_log.log', 'options': ['daily', 'weekly', 'size 4M', 'rotate 7', 'missingok', 'compress', 'delaycompress', 'copytruncate']})

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************
changed: [centOS1-Knossos]

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************
changed: [centOS1-Knossos]

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************
changed: [centOS1-Knossos]

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************
changed: [centOS1-Knossos]

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************
changed: [centOS1-Knossos]

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************
fatal: [centOS1-Knossos]: FAILED! => changed=false 
  msg: |-
    Unable to restart service fail2ban: Job for fail2ban.service failed because start of the service was attempted too often. See "systemctl status fail2ban.service" and "journalctl -xe" for details.
    To force a start use "systemctl reset-failed fail2ban.service" followed by "systemctl start fail2ban.service" again.

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************

RUNNING HANDLER [commons : restart fail2ban (with service)] *******************************************************************************************************************************************************

RUNNING HANDLER [commons : restart firewall] **********************************************************************************************************************************************************************

NO MORE HOSTS LEFT ************************************************************************************************************************************************************************************************

```
</details>



[It has already been reported](https://github.com/ansible/ansible/issues/49371).