### PR TITLE
DEVOPS-39 Migration tests of the role disable_ipv6 in Ansible 2.9.3

### DIFF
--- a/roles/disable_ipv6/tasks/main.yml
+++ b/roles/disable_ipv6/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: disable ipv6
   sysctl: 
     name: '{{ item }}' 
-    value: 1
+    value: '1'
     state: present
     reload: no
   loop:


### PR DESCRIPTION
Because of this warning :
```
[WARNING]: The value 1 (type int) in a string field was converted to u'1' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```