### PR TITLE
DEVOPS-34 Migration tests of the role argo-api-authn in Ansible 2.9.3

### DIFF
--- a/roles/argo-api-authn/tasks/python-env-setup.yml
+++ b/roles/argo-api-authn/tasks/python-env-setup.yml
@@ -21,6 +21,7 @@
 - name: install virtualenv with pip
   pip:
    name: "virtualenv"
+   executable: pip3.6
   tags: authn_env_install
 
 - name: install git


### PR DESCRIPTION
Because the **virtualenv** package was installed by pip**2** rather than pip**3.6**, this caused the following problem:
```bash
TASK [argo-api-authn : Create a virtualenv and install the requirements] *******************************************************************
fatal: [centos7_devel_1]: FAILED! => changed=false 
  invocation:
    module_args:
      chdir: null
      editable: false
      executable: null
      extra_args: null
      name:
      - git+https://github.com/ARGOeu/argo-api-authn.git@devel#egg=argo-api-authn-scripts
      requirements: null
      state: present
      umask: null
      version: null
      virtualenv: /opt/virtualenv/authn-env
      virtualenv_command: virtualenv
      virtualenv_python: python3.6
      virtualenv_site_packages: false
  msg: |-
    Could not get output from /usr/bin/virtualenv --help: Traceback (most recent call last):
      File "/usr/bin/virtualenv", line 7, in <module>
        from virtualenv.__main__ import run_with_catch
      File "/usr/lib/python2.7/site-packages/virtualenv/__init__.py", line 3, in <module>
        from .run import cli_run
      File "/usr/lib/python2.7/site-packages/virtualenv/run/__init__.py", line 12, in <module>
        from .plugin.activators import ActivationSelector
      File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/activators.py", line 6, in <module>
        from .base import ComponentBuilder
      File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/base.py", line 9, in <module>
        from importlib_metadata import entry_points
      File "/usr/lib/python2.7/site-packages/importlib_metadata/__init__.py", line 9, in <module>
        import zipp
    ImportError: No module named zipp

PLAY RECAP *********************************************************************************************************************************
centos7_devel_1            : ok=18   changed=0    unreachable=0    failed=1    skipped=7    rescued=0    ignored=0
```
