### PR TITLE
DEVOPS-49 Migration tests of the role webapi in Ansible 2.9.3

### DIFF
--- a/roles/webapi/tasks/deploy.yml
+++ b/roles/webapi/tasks/deploy.yml
@@ -31,7 +31,7 @@
 
 - name: reload systemd
   command: /usr/bin/systemctl --system daemon-reload
-  when: argowebapi_service | changed
+  when: argowebapi_service.changed
   tags: webapi_deploy
 ################################################################################
 


### PR DESCRIPTION
In Ansible 2.9.3 the syntax has changed slightly.

I have this error with the existing implementation :
```
TASK [webapi : Setup argo-web-api service] **********************************************
changed: [centos7-argo-web-api]

TASK [webapi : reload systemd] **********************************************
fatal: [centos7-argo-web-api]: FAILED! => 
  msg: |-
    The conditional check 'argowebapi_service | changed' failed. The error was: template error while templating string: no filter named 'changed'. String: {% if argowebapi_service | changed %} True {% else %} False {% endif %}
  
    The error appears to be in '/home/tas-sos/workspace/ansible/argo-ansible-deploy/argo-ansible/roles/webapi/tasks/deploy.yml': line 32, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: reload systemd
      ^ here


RUNNING HANDLER [mongodb : restart mongo] **********************************************

RUNNING HANDLER [webapi : restart argo-web-api service] **********************************************

PLAY RECAP **********************************************
centos7-argo-web-api    : ok=56   changed=37   unreachable=0    failed=1    skipped=34   rescued=0    ignored=0
```

After the current change for the first time: 
```
TASK [webapi : Setup argo-web-api service] ************************************************************************************************************************************************************************
task path: ..../argo-ansible-deploy/argo-ansible/roles/webapi/tasks/deploy.yml:27

changed: [centos7-argo-web-api] => changed=true 
  checksum: 6446f66772db5c62817d66573258c65c13902f1d
  dest: /etc/systemd/system/argo-web-api.service
  diff: []
  gid: 0
  group: root
  invocation:
    module_args:
      _original_basename: argo-web-api.service.j2
      attributes: null
      backup: false
      checksum: 6446f66772db5c62817d66573258c65c13902f1d
      content: null
      delimiter: null
      dest: /etc/systemd/system/argo-web-api.service
      directory_mode: null
      follow: false
      force: true
      group: null
      local_follow: null
      mode: null
      owner: null
      regexp: null
      remote_src: null
      selevel: null
      serole: null
      setype: null
      seuser: null
      src: /root/.ansible/tmp/ansible-tmp-1584000764.949441-152508053816060/source
      unsafe_writes: null
      validate: null
  md5sum: 0620f9512264ee84fa8eaacb703d070c
  mode: '0644'
  owner: root
  size: 281
  src: /root/.ansible/tmp/ansible-tmp-1584000764.949441-152508053816060/source
  state: file
  uid: 0


TASK [webapi : reload systemd] ************************************************************************************************************************************************************************************
task path: ..../argo-ansible-deploy/argo-ansible/roles/webapi/tasks/deploy.yml

changed: [centos7-argo-web-api] => changed=true 
  cmd:
  - /usr/bin/systemctl
  - --system
  - daemon-reload
  delta: '0:00:00.208722'
  end: '2020-03-12 10:12:52.489657'
  invocation:
    module_args:
      _raw_params: /usr/bin/systemctl --system daemon-reload
      _uses_shell: false
      argv: null
      chdir: null
      creates: null
      executable: null
      removes: null
      stdin: null
      stdin_add_newline: true
      strip_empty_ends: true
      warn: true
  rc: 0
  start: '2020-03-12 10:12:52.280935'
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```

After the current change the second time :
```
TASK [webapi : Setup argo-web-api service] ************************************************************************************************************************************************************************
task path: ..../argo-ansible-deploy/argo-ansible/roles/webapi/tasks/deploy.yml:27

ok: [centos7-argo-web-api] => changed=false 
  checksum: 6446f66772db5c62817d66573258c65c13902f1d
  dest: /etc/systemd/system/argo-web-api.service
  diff:
    after:
      path: /etc/systemd/system/argo-web-api.service
    before:
      path: /etc/systemd/system/argo-web-api.service
  gid: 0
  group: root
  invocation:
    module_args:
      _diff_peek: null
      _original_basename: argo-web-api.service.j2
      access_time: null
      access_time_format: '%Y%m%d%H%M.%S'
      attributes: null
      backup: null
      content: null
      delimiter: null
      dest: /etc/systemd/system/argo-web-api.service
      directory_mode: null
      follow: false
      force: false
      group: null
      mode: null
      modification_time: null
      modification_time_format: '%Y%m%d%H%M.%S'
      owner: null
      path: /etc/systemd/system/argo-web-api.service
      recurse: false
      regexp: null
      remote_src: null
      selevel: null
      serole: null
      setype: null
      seuser: null
      src: null
      state: file
      unsafe_writes: null
  mode: '0644'
  owner: root
  path: /etc/systemd/system/argo-web-api.service
  size: 281
  state: file
  uid: 0

TASK [webapi : reload systemd] ************************************************************************************************************************************************************************************
task path: ..../argo-ansible-deploy/argo-ansible/roles/webapi/tasks/deploy.yml:32

skipping: [centos7-argo-web-api] => changed=false 
  skip_reason: Conditional result was False
```

