### PR TITLE
DEVOPS-41 Migration tests of the role metrics in Ansible 2.9.3

### DIFF
--- a/roles/metrics/tasks/ce_comp.yml
+++ b/roles/metrics/tasks/ce_comp.yml
@@ -10,9 +10,17 @@
     path: ~/Envs/ce_comp_env
     state: directory
 
+- name: upgrade pip2.7
+  pip:
+    name: pip
+    executable: pip2.7
+    state: latest
+    extra_args: --upgrade
+
 - name: install virtualenv with pip
   pip:
     name: "virtualenv"
+    executable: pip2.7
 
 - name: create directory for the generated html reports
   file:
@@ -41,7 +49,7 @@
     cron_file: ce_comp_{{ item.name | lower }}
     name: "set up cron for {{ item.name }}"
     user: root
-    hour: 4
+    hour: "4"
     job: "~/Envs/ce_comp_env/bin/python ~/Envs/ce_comp_env/ce_comp/ce_comp.py -t {{ item.name }} -s html -c ~/Envs/ce_comp_env/ce_comp/config.cfg -sd $(date --date yesterday '+\\%Y-\\%m-\\%d') -ed $(date --date yesterday '+\\%Y-\\%m-\\%d') -sp /var/www/html/ce_comp/"
   loop: "{{ tenants }}"
   loop_control:


### PR DESCRIPTION
Because of the following `FAILED` & `WARNING`:

```
TASK [metrics : Create a virtualenv for the script] ***************************************************************************************************************************************************************
fatal: [centos7-metricsVM]: FAILED! => changed=false 
  msg: |-
    Could not get output from /usr/bin/virtualenv --help: Traceback (most recent call last):
      File "/usr/bin/virtualenv", line 7, in <module>
        from virtualenv.__main__ import run_with_catch
      File "/usr/lib/python2.7/site-packages/virtualenv/__init__.py", line 3, in <module>
        from .run import cli_run
      File "/usr/lib/python2.7/site-packages/virtualenv/run/__init__.py", line 12, in <module>
        from .plugin.activators import ActivationSelector
      File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/activators.py", line 6, in <module>
        from .base import ComponentBuilder
      File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/base.py", line 9, in <module>
        from importlib_metadata import entry_points
      File "/usr/lib/python2.7/site-packages/importlib_metadata/__init__.py", line 9, in <module>
        import zipp
    ImportError: No module named zipp
```

```
TASK [metrics : set up cron] **************************************************************************************************************************************************************************************
changed: [centos7-metricsVM] => (item=EUDAT)
changed: [centos7-metricsVM] => (item=EGI)
[WARNING]: The value 4 (type int) in a string field was converted to u'4' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```