### PR TITLE
DEVOPS-31 Migration tests of the role alerta in Ansible 2.9.3

### DIFF
--- a/roles/alerta/defaults/main.yml
+++ b/roles/alerta/defaults/main.yml
@@ -45,6 +45,5 @@ alerta_tenants:
     mail_type: html
     mail_debug: true
     mail_rule: ~/alerta-foo/mail-rules/mail-foo-rules.json
-    ui_endpoint: localhost
 
 smtp_debug: true

--- a/roles/alerta/files/uwsgi.service
+++ b/roles/alerta/files/uwsgi.service
@@ -1,8 +1,25 @@
 [Unit]
-Description=uWSGI service
+Description=Alerta uWSGI service
+After=syslog.target
 
 [Service]
+User=uwsgi
+Group=www-data
 ExecStart=/opt/alerta/bin/uwsgi --ini /etc/uwsgi.ini
+ExecStartPre=/usr/bin/mkdir -p /var/run/uwsgi
+ExecStartPre=/usr/bin/chown uwsgi:www-data /var/run/uwsgi
+ExecStartPre=/usr/bin/chmod 0755 /var/run/uwsgi
+PermissionsStartOnly=true
+PIDFile=/var/run/uwsgi/uwsgi.pid
+
+# Requires systemd version 211 or newer
+RuntimeDirectory=uwsgi
+Restart=always
+#KillSignal=SIGQUIT
+Type=notify
+StandardError=syslog
+NotifyAccess=all
+
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/alerta/tasks/deploy.yml
+++ b/roles/alerta/tasks/deploy.yml
@@ -24,6 +24,7 @@
   pip:
     name: virtualenv
     state: present
+    executable: pip3.6
   tags: alerta
 
 - name: Install Alerta
@@ -49,6 +50,17 @@
     name: uwsgi
     virtualenv: '{{ alerta_server_dir }}'
     state: forcereinstall
+
+- name: (pip) Uninstall Werkzeug 1.0.0 [Fix 'werkzeug.contrib' problem (1/2)]
+  pip:
+    name: werkzeug
+    state: absent
+    virtualenv: '{{ alerta_server_dir }}'
+
+- name: (pip) Install Werkzeug 0.16.1 [Fix 'werkzeug.contrib' problem (2/2)]
+  pip:
+    name: werkzeug==0.16.1
+    virtualenv: '{{ alerta_server_dir }}'
 
 - name: Add www-data group 
   tags: alerta
@@ -301,7 +313,13 @@
     src: hosts.j2
     dest: /etc/hosts
 
-- name: Configure supervisord
+- name: establish supervisord config directory
+  tags: alerta
+  file:
+    path: /etc/supervisord
+    state: directory
+
+- name: Configure supervisord (1/2)
   tags: alerta
   template:
     src: supervisord.conf.j2
@@ -309,7 +327,7 @@
     mode: 0444
   notify: restart supervisord
 
-- name: Configure supervisord
+- name: Configure supervisord (2/2)
   tags: alerta
   template:
     src: supervisord.conf.j2
@@ -339,3 +357,5 @@
   service:
     name: nginx
     state: started
+
+# vim: syntax=yaml ts=4 sw=4 sts=4 sr noet

--- a/roles/alerta/templates/supervisord.conf.j2
+++ b/roles/alerta/templates/supervisord.conf.j2
@@ -147,7 +147,7 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 ;[include]
 ;files = relative/directory/*.ini
 
-{% for key, value in alerta_tenants.iteritems() %}
+{% for key, value in alerta_tenants.items() %}
 [program:alert-pub-{{key}}]
 command={{ alerta_server_dir }}/bin/python {{ alerta_server_dir }}/bin/argo-alert-publisher -c /etc/argo-alert/argo-alert-{{key}}.conf
 autostart=false


### PR DESCRIPTION
* [x] Fixed a duplicate default variable.
```bash
[WARNING]: While constructing a mapping from ...../argo-ansible-deploy/argo-ansible/roles/alerta/defaults/main.yml, line 40, column 5, found a duplicate dict key (ui_endpoint). Using
last defined value only.
```

* [x] Choose specific version of pip to install virtualenv. 
[  [pip install virtualenv broken / missing zipp package #1630](https://github.com/pypa/virtualenv/issues/1630)  ]
```bash
TASK [alerta : Install Alerta] *********************************************************************************************************
fatal: [centos7_devel_2]: FAILED! => changed=false 
  msg: |-
    Could not get output from /usr/bin/virtualenv --help: Traceback (most recent call last):
      File "/usr/bin/virtualenv", line 7, in <module>
        from virtualenv.__main__ import run_with_catch
      File "/usr/lib/python2.7/site-packages/virtualenv/__init__.py", line 3, in <module>
        from .run import cli_run
      File "/usr/lib/python2.7/site-packages/virtualenv/run/__init__.py", line 12, in <module>
        from .plugin.activators import ActivationSelector
      File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/activators.py", line 6, in <module>
        from .base import ComponentBuilder
      File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/base.py", line 9, in <module>
        from importlib_metadata import entry_points
      File "/usr/lib/python2.7/site-packages/importlib_metadata/__init__.py", line 9, in <module>
        import zipp
    ImportError: No module named zipp
```

* [x] Fixed python iteration.
```bash
TASK [alerta : Configure supervisord] **************************************************************************************************
fatal: [centos7_devel_2]: FAILED! => changed=false 
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''iteritems'''
```

* [x] Fixed supervisord directory.
```bash
TASK [alerta : Configure supervisord] **************************************************************************************************
fatal: [centos7_devel_2]: FAILED! => changed=false 
  checksum: c69428cea9c9ea57e59c3f9b9a690c781d433d2b
  msg: Destination directory /etc/supervisord does not exist
```

* [x] Fixed the uWSGI.service so that it creates whenever it runs the directory in the `/var/run/`.

* [x] Fixed the problem with Werkzeug **1.0.0**. 
```bash
# alertad version
Traceback (most recent call last):
  File "/opt/alerta/bin/alertad", line 5, in <module>
    from alerta.commands import cli
  File "/opt/alerta/lib/python3.6/site-packages/alerta/__init__.py", line 28, in <module>
    from .app import create_app  # noqa
  File "/opt/alerta/lib/python3.6/site-packages/alerta/app.py", line 7, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ModuleNotFoundError: No module named 'werkzeug.contrib'
```
Due to the fact that the **latest** release of Werkzeug includes **breaking changes**.
This problem has been already reported here: 
* [Latest werkzeug broke Alerta #1137](https://github.com/alerta/alerta/issues/1137)
* [Import ProxyFix from werkzeug.middleware.proxy_fix #1095](https://github.com/alerta/alerta/pull/1095)
* [Werkzeug Version 1.0.1 Changelog](https://werkzeug.palletsprojects.com/en/1.0.x/changes/)
* [ Werkzeug Documentation **0.15.x** - **Fixers**](https://werkzeug.palletsprojects.com/en/0.15.x/contrib/fixers/)
> Deprecated since version 0.15: ProxyFix has moved to werkzeug.middleware.proxy_fix. All other code in this module is deprecated and will be removed in version 1.0.

So either I had to upgrade the alerta version or **downgrade** the **werkzeug** version.
In our case I chose the second.

