### PR TITLE
DEVOPS-40 Migration tests of the role flink in Ansible 2.9.3

### DIFF
--- a/roles/flink/tasks/main.yml
+++ b/roles/flink/tasks/main.yml
@@ -26,9 +26,10 @@
   tags: flink_install
 
 - name: Remove older downloaded flink
-  command: rm -f {{flink_dir}}/flink-{{flink_version}}.tgz
+  file:
+    path: "{{flink_dir}}/flink-{{flink_version}}.tgz"
+    state: absent
   tags: flink_install
-  ignore_errors: True
 
 - name: Download Flink
   get_url: url={{flink_url}} dest={{flink_dir}}/flink-{{flink_version}}.tgz timeout=100
@@ -38,7 +39,12 @@
     https_proxy: "{{http_proxy_url}}"
 
 - name: Unpack tarball
-  command: tar xzf {{flink_dir}}/flink-{{flink_version}}.tgz --strip-components=1 chdir={{flink_dir}} creates={{flink_dir}}/bin
+  unarchive:
+    src: "{{flink_dir}}/flink-{{flink_version}}.tgz"
+    dest: "{{flink_dir}}"
+    extra_opts:
+    - --strip-components=1
+    remote_src: yes
   tags: flink_install
 
 - name: Setup flink-conf


### PR DESCRIPTION
Changes to eliminate the following warnings :

```
TASK [flink : Remove older downloaded flink] **********************************************************************************************************************************************************************
[WARNING]: Consider using the file module with state=absent rather than running 'rm'.  If you need to use command because file is insufficient you can add 'warn: false' to this command task or set
'command_warnings=False' in ansible.cfg to get rid of this message.
```


```
TASK [flink : Unpack tarball] *************************************************************************************************************************************************************************************
[WARNING]: Consider using the unarchive module rather than running 'tar'.  If you need to use command because unarchive is insufficient you can add 'warn: false' to this command task or set
'command_warnings=False' in ansible.cfg to get rid of this message.
```