### PR TITLE
sSMTP MTA role.

### DIFF
--- a/roles/ssmtp/README.md
+++ b/roles/ssmtp/README.md
@@ -1,0 +1,44 @@
+sSMTP Role
+=========
+
+sSMTP role sets up sSMTP MTA so that you can send emails from your virtual machine (VM) via `relay.grnet.gr`.
+> Of course the role can also be used to set up email through other providers with minor changes.
+
+Requirements
+------------
+
+You should be allowed to send emails through the grnet relay. To be allowed, you should contact the support department at `support@grnet.gr`.
+
+Role Variables
+--------------
+
+The role has no variables and essentially does not need any variables to execute.
+However, for the better user experience only, the following **optional** variables have been defined:
+
+* `domain` (optional) : The domain name of the machine through which the test email will be sent.
+* `ansible_user_email` (optional) : The email address to which the test email will be sent.
+
+> As understood from the above, the role at the end for testing purposes also undertakes to send a test email to an address of your choice.
+
+The above variables can be defined very easily in the `host_vars` file of the target machine.
+
+
+Example Playbook
+----------------
+
+```
+- name: sSMTP
+  hosts: all
+  roles:
+    - {role: 'ssmtp', tags: 'MTA'}
+```
+
+License
+-------
+
+Apache 2.0
+
+Author Information
+------------------
+
+GRNET

--- a/roles/ssmtp/files/revaliases
+++ b/roles/ssmtp/files/revaliases
@@ -1,0 +1,7 @@
+# sSMTP aliases
+# 
+# Format:       local_account:outgoing_address:mailhub
+#
+# Example: root:your_login@your.domain:mailhub.your.domain[:port]
+# where [:port] is an optional port number that defaults to 25.
+root:no-reply@grnet.gr:relay.grnet.gr:587

--- a/roles/ssmtp/tasks/main.yml
+++ b/roles/ssmtp/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# tasks file for ssmtp
+
+# Installation.
+- debug:
+    msg: ssmtp package is only available on CentOS 7.
+
+- name: Remove all ther Mail Transport Agent software.
+  yum:
+    name: postfix
+    state: absent
+
+- name: Install the latest version of sSMTP MTA.
+  yum:
+    name: ssmtp
+    state: present
+
+
+# Configuration.
+- name: Revaliases configuration.
+  copy:
+    src: revaliases
+    dest: /etc/ssmtp/revaliases
+    backup: no
+    owner: root
+    group: root
+    mode: 0644
+
+- name: sSMTP configuration file.
+  template:
+    src: ssmtp.conf.j2
+    dest: /etc/ssmtp/ssmtp.conf
+
+- name: sSMTP email sending test.
+  shell: echo "With sSMTP 2.x MTA form {{ domain }}" | mail -vvvv -s "[Ansible Mail Test] {{ domain }}" {{ ansible_user_email }}
+  when: ansible_user_email is defined
+
+
+# Test.
+- name: About sSMTP MTA.
+  debug:
+    msg:
+    - "To make sure that the sSMTP MTA is working properly, run the following command:"
+    - "To test how it works, run the following command:"
+    - "echo test | ssmtp -v user@test.example.com"
+
+# Logs.
+- debug:
+    msg:
+    - "To make sure it was sent correctly, look at the log files \"var/log/maillog\""
+    - "tail -f /var/log/maillog"
+    - "lnav /var/log/maillog"
+

--- a/roles/ssmtp/templates/ssmtp.conf.j2
+++ b/roles/ssmtp/templates/ssmtp.conf.j2
@@ -1,0 +1,54 @@
+#
+# /etc/ssmtp.conf -- a config file for sSMTP sendmail.
+#
+# See the ssmtp.conf(5) man page for a more verbose explanation of the
+# available options.
+#
+# The person who gets all mail for userids < 1000
+# Make this empty to disable rewriting.
+#root=postmaster
+root=no-reply@grnet.gr
+
+# The place where the mail goes. The actual machine name is required
+# no MX records are consulted. Commonly mailhosts are named mail.domain.com
+# The example will fit if you are in domain.com and your mailhub is so named.
+#mailhub=mail
+mailhub=relay.grnet.gr:587
+
+# Example for SMTP port number 2525
+# mailhub=mail.your.domain:2525
+# Example for SMTP port number 25 (Standard/RFC)
+# mailhub=mail.your.domain        
+# Example for SSL encrypted connection
+# mailhub=mail.your.domain:465
+
+# Where will the mail seem to come from?
+#RewriteDomain=
+
+# The full hostname
+#Hostname=
+Hostname={{ domain }}
+
+# Set this to never rewrite the "From:" line (unless not given) and to
+# use that address in the "from line" of the envelope.
+#FromLineOverride=YES
+FromLineOverride=YES
+
+# Use SSL/TLS to send secure messages to server.
+#UseTLS=YES
+#IMPORTANT: The following line is mandatory for TLS authentication
+TLS_CA_File=/etc/pki/tls/certs/ca-bundle.crt
+
+# Use SSL/TLS certificate to authenticate against smtp host.
+#UseTLSCert=YES
+
+# Use this RSA certificate.
+#TLSCert=/etc/pki/tls/private/ssmtp.pem
+
+# Get enhanced (*really* enhanced) debugging information in the logs
+# If you want to have debugging of the config file parsing, move this option
+# to the top of the config file and uncomment
+#Debug=YES
+
+# Because GRNET **required** StartTLS !
+UseSTARTTLS=YES


### PR DESCRIPTION
This role undertakes the installation and configuration of sSMTP Mail Transfer Agent (MTA).

Tested on **CentOS 7 Linux**.