### PR TITLE
DEVOPS-244 Move links to https

### DIFF
--- a/roles/swagger/files/var/www/html/index.html
+++ b/roles/swagger/files/var/www/html/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<!-- saved from url=(0024)http://argoeu.github.io/ -->
+<!-- saved from url=(0024)https://argoeu.github.io/ -->
 <html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">  
   <title>ARGO Availability and Reliability Monitoring - ARGO Documentation</title>
-  <link rel="alternate" type="application/atom+xml" title="API Changes" href="http://argoeu.github.io/changes.atom">
+  <link rel="alternate" type="application/atom+xml" title="API Changes" href="https://argoeu.github.io/changes.atom">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. ">
@@ -10,12 +10,12 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="ARGO Availability and Reliability Monitoring">
     <meta property="og:description" content="ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures.">
-    <meta property="og:url" content="http://argoeu.github.io/">
+    <meta property="og:url" content="https://argoeu.github.io/">
     <meta property="og:site_name" content="ARGO Documentation">
     <meta property="article:publisher" content="ARGO Team">
-    <meta property="og:image" content="http://argoeu.github.io/shared/images/argo-logo.png">
+    <meta property="og:image" content="https://argoeu.github.io/shared/images/argo-logo.png">
   <meta name="author" content="">
-  <link rel="icon" href="http://argoeu.github.io/shared/favicon.ico">
+  <link rel="icon" href="https://argoeu.github.io/shared/favicon.ico">
   <!-- Bootstrap core CSS -->
   <link href="./assets/bootstrap.min.css" rel="stylesheet">
   
@@ -42,12 +42,11 @@
 		    <span class="icon-bar"></span>
 		    <span class="icon-bar"></span>
 		  </button>
-		  <a class="navbar-brand" href="http://argoeu.github.io/index.html"><img src="./assets/argo-logo.png" alt="ARGO"></a>
+		  <a class="navbar-brand" href="https://argoeu.github.io/index.html"><img src="./assets/argo-logo.png" alt="ARGO"></a>
 		</div>
 		<div id="navbar" class="navbar-collapse collapse">
 		  <ul class="nav navbar-nav navbar-right">
-		  	<li><a href="http://argoeu.github.io/"> Main Site</a></li>
-		
+		  	<li><a href="https://argoeu.github.io/"> Main Site</a></li>
 		  </ul>
 		</div><!--/.nav-collapse -->
 	</div><!--container-->
@@ -106,7 +105,7 @@
         <div class=" col-md-offset-1 col-md-3">
 		<p><img src="./assets/argo-logo.png" alt="Argo"></p>		
 		<p>ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. 
-		Learn more: <a href='http://argoeu.github.io/' style='color:white;'>http://argoeu.github.io/</a></p>
+		Learn more: <a href='https://argoeu.github.io/' style='color:white;'>https://argoeu.github.io/</a></p>
    	</div>
 	 <div class="col-md-offset-1 col-md-3">
 		<h4>Contact Us</h4>

--- a/roles/swagger/templates/index.html.j2
+++ b/roles/swagger/templates/index.html.j2
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<!-- saved from url=(0024)http://argoeu.github.io/ -->
+<!-- saved from url=(0024)https://argoeu.github.io/ -->
 <html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>ARGO Availability and Reliability Monitoring - ARGO Documentation</title>
-  <link rel="alternate" type="application/atom+xml" title="API Changes" href="http://argoeu.github.io/changes.atom">
+  <link rel="alternate" type="application/atom+xml" title="API Changes" href="https://argoeu.github.io/changes.atom">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. ">
@@ -10,12 +10,12 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="ARGO Availability and Reliability Monitoring">
     <meta property="og:description" content="ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures.">
-    <meta property="og:url" content="http://argoeu.github.io/">
+    <meta property="og:url" content="https://argoeu.github.io/">
     <meta property="og:site_name" content="ARGO Documentation">
     <meta property="article:publisher" content="ARGO Team">
-    <meta property="og:image" content="http://argoeu.github.io/shared/images/argo-logo.png">
+    <meta property="og:image" content="https://argoeu.github.io/shared/images/argo-logo.png">
   <meta name="author" content="">
-  <link rel="icon" href="http://argoeu.github.io/shared/favicon.ico">
+  <link rel="icon" href="https://argoeu.github.io/shared/favicon.ico">
   <!-- Bootstrap core CSS -->
   <link href="./assets/bootstrap.min.css" rel="stylesheet">
 
@@ -42,12 +42,11 @@
 		    <span class="icon-bar"></span>
 		    <span class="icon-bar"></span>
 		  </button>
-		  <a class="navbar-brand" href="http://argoeu.github.io/index.html"><img src="./assets/argo-logo.png" alt="ARGO"></a>
+		  <a class="navbar-brand" href="https://argoeu.github.io/index.html"><img src="./assets/argo-logo.png" alt="ARGO"></a>
 		</div>
 		<div id="navbar" class="navbar-collapse collapse">
 		  <ul class="nav navbar-nav navbar-right">
-		  	<li><a href="http://argoeu.github.io/"> Main Site</a></li>
-
+		  	<li><a href="https://argoeu.github.io/"> Main Site</a></li>
 		  </ul>
 		</div><!--/.nav-collapse -->
 	</div><!--container-->
@@ -94,21 +93,21 @@
         <div class="col-lg-2">
         </div>
           <div class="col-lg-3">
-              <a href="http://argoeu.github.io/api/v2/" target="_blank">
+              <a href="https://argoeu.github.io/api/v2/" target="_blank">
               	<span ><img src="./assets/argo-web-mkdocs.png" alt="ARGO" class="fa-grey"></span></a>
-              <h2><a href="http://argoeu.github.io/messaging/v1/"> ARGO Web API</a></h2>
+              <h2><a href="https://argoeu.github.io/messaging/v1/"> ARGO Web API</a></h2>
               <p> Detailed documentation about the ARGO web api.</p>
           </div><!-- /.col-lg-4 -->
        	  <div class="col-lg-3">
-              <a href="http://argoeu.github.io/messaging/v1/" target="_blank">
+              <a href="https://argoeu.github.io/messaging/v1/" target="_blank">
               	<span ><img src="./assets/messaging-api-mkdocs.png" alt="ARGO" class="fa-grey"></span></a>
-              <h2><a href="http://argoeu.github.io/messaging/v1/"> ARGO Messaging API</a></h2>
+              <h2><a href="https://argoeu.github.io/messaging/v1/"> ARGO Messaging API</a></h2>
               <p> Detailed documentation about the ARGO Messaging api.</p>
           </div><!-- /.col-lg-4 -->
           <div class="col-lg-3">
-              <a href="http://argoeu.github.io/ams-library/" target="_blank">
+              <a href="https://argoeu.github.io/ams-library/" target="_blank">
               	<span ><img src="./assets/ams-library-docs.png" alt="ARGO" class="fa-grey"></span></a>
-              <h2><a href="http://argoeu.github.io/ams-library/"> ARGO AMS Library</a></h2>
+              <h2><a href="https://argoeu.github.io/ams-library/"> ARGO AMS Library</a></h2>
               <p>  Detailed documentation about the AMS Library</p>
           </div><!-- /.col-lg-4 -->
 		 <div class="col-lg-1">
@@ -118,11 +117,11 @@
 		<div class="col-lg-2">
 		</div>
 		<div class="col-lg-3">
-			<a href="http://argoeu.github.io/poem/v1/" target="_blank">
+			<a href="https://argoeu.github.io/poem/v1/" target="_blank">
 
 				<span ><img src="./assets/poem-2.png" alt="ARGO" class="fa-grey"></span></a>
 
-			<h2><a href="http://argoeu.github.io/poem/v1/"> POEM</a></h2>
+			<h2><a href="https://argoeu.github.io/poem/v1/"> POEM</a></h2>
 
 			<p> Detailed documentation about POEM Component.</p>
 		</div><!-- /.col-lg-4 -->
@@ -147,7 +146,7 @@
         <div class=" col-md-offset-1 col-md-3">
 		<p><img src="./assets/argo-logo.png" alt="Argo"></p>
 		<p>ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures.
-		Learn more: <a href='http://argoeu.github.io/' style='color:white;'>http://argoeu.github.io/</a></p>
+		Learn more: <a href='https://argoeu.github.io/' style='color:white;'>https://argoeu.github.io/</a></p>
    	</div>
 	 <div class="col-md-offset-1 col-md-3">
 		<h4>Contact Us</h4>


### PR DESCRIPTION
Replace http links with https because firefox sets a warning for unsafe objects in this page.