### PR TITLE
Add installation of external tools

### DIFF
--- a/roles/icinga_agent/tasks/common_Debian.yml
+++ b/roles/icinga_agent/tasks/common_Debian.yml
@@ -67,6 +67,7 @@
     url: https://raw.githubusercontent.com/ARGOeu/argo-external-tools/master/src/check_mem.pl
     dest: /usr/lib/nagios/plugins
     mode: 0755
+  tags: icinga_external_tools
 
 
 - name: Configuration Syntax Highlighting using Vim.

--- a/roles/icinga_agent/tasks/common_Debian.yml
+++ b/roles/icinga_agent/tasks/common_Debian.yml
@@ -62,6 +62,11 @@
     update_cache: yes
 
 
+- name: Get check_mem.pl external probe
+  get_url:
+    url: https://raw.githubusercontent.com/ARGOeu/argo-external-tools/master/src/check_mem.pl
+    dest: /usr/lib/nagios/plugins
+    mode: 0755
 
 
 - name: Configuration Syntax Highlighting using Vim.

--- a/roles/icinga_agent/tasks/common_RedHat.yml
+++ b/roles/icinga_agent/tasks/common_RedHat.yml
@@ -36,6 +36,10 @@
     state: latest
 
 
+- name: Install Argo External Plugins.
+  yum:
+    name: argo-external-tools
+    state: latest
 
 
 - name: Install Icinga 2 SELinux policy and some utils.

--- a/roles/icinga_agent/tasks/common_RedHat.yml
+++ b/roles/icinga_agent/tasks/common_RedHat.yml
@@ -40,6 +40,7 @@
   yum:
     name: argo-external-tools
     state: latest
+  tags: icinga_external_tools
 
 
 - name: Install Icinga 2 SELinux policy and some utils.


### PR DESCRIPTION
Add argo-external-tools installation icinga agent role.
On debian we can't use the rpm package so we decided to downloaded to the nagios/plugins folder directly wit get_url