### PR TITLE
ARGO-2761 Update HAproxy vars with new timeout value

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -2,7 +2,8 @@
 # defaults file for haproxy
 
 haproxy_retries: 3
-haproxy_timeout_http_request: 5000
+haproxy_timeout_http_request: 10s
+haproxy_timeout_http_request_frontend: 10s
 haproxy_timeout_queue: 5000
 haproxy_timeout_connect: 5000
 haproxy_timeout_client: 10000

--- a/roles/haproxy/templates/haproxy_template.cfg.j2
+++ b/roles/haproxy/templates/haproxy_template.cfg.j2
@@ -109,7 +109,7 @@ frontend  {{haproxy_frontend}}
    option forwardfor
    reqadd X-Forwarded-Proto:\ https
    reqadd X-Forwarded-Port:\ 443
-
+   timeout http-request {{haproxy_timeout_http_request_frontend}}
 #---------------------------------------------------------------------
 # round robin balancing between the various msg backends
 #---------------------------------------------------------------------


### PR DESCRIPTION
Update the haproxy template to have a configurable variable for frontend HTTP time out requests with a default value fo 10 seconds