### PR TITLE
Enable httpd.

### DIFF
--- a/roles/apache/handlers/main.yml
+++ b/roles/apache/handlers/main.yml
@@ -4,4 +4,5 @@
 - name: restart httpd
   service:
     name: httpd
+    enabled: yes
     state: restarted


### PR DESCRIPTION
We also need to enable httpd so that it starts automatically when the system starts.