### PR TITLE
Apache: Fixed some issues with certificates.

### DIFF
--- a/roles/apache/tasks/backup.yml
+++ b/roles/apache/tasks/backup.yml
@@ -5,8 +5,13 @@
     path: /etc/httpd
   register: httpd_folder
 
+- name: Ensure "{{ backup_dir }}" directory exists
+  file:
+    path: "{{ backup_dir }}"
+    state: directory
+
 - name: Compress backup directory
   archive:
-    path:  "/etc/httpd/"
+    path: "/etc/httpd/"
     dest: "{{ backup_dir }}/httpd_{{ansible_date_time.iso8601_basic_short}}.tgz"
   when: httpd_folder.stat.exists and httpd_folder.stat.isdir

--- a/roles/apache/templates/virtualhost.j2
+++ b/roles/apache/templates/virtualhost.j2
@@ -14,7 +14,7 @@
   SSLCertificateFile {{cert_path}}
   SSLCertificateKeyFile {{cert_key_path}}
 {% if is_chain_file %}
-  SSLCertificateChainFile {{ca_path}}/chain-{{inventory_hostname}}.pem
+  SSLCertificateChainFile {{ca_path}}chain-{{inventory_hostname}}.pem
 {% endif %}
 
 {% if httpd_extra_conf is defined %}

--- a/roles/commons/tasks/cert.yml
+++ b/roles/commons/tasks/cert.yml
@@ -3,21 +3,21 @@
 - name: Create cert_dir if not exists
   file: dest={{ cert_dir }} state=directory
         owner=root group=root mode=0755
-  when: cert_dir is defined and requires_cert == 'True'
+  when: cert_dir is defined and requires_cert | default(True) | bool == True
   tags: cert
 
 - name: Copy host x509 certificate onto host
   copy: src=private_files/{{ inventory_hostname }}/{{ inventory_hostname }}.pem
         dest={{ cert_path }} backup=yes
         owner=root group=root mode=0644
-  when: cert_dir is defined and requires_cert == 'True'
+  when: cert_dir is defined and requires_cert | default(True) | bool == True
   tags: cert
 
 - name: Copy host x509 key onto host
   copy: src=private_files/{{ inventory_hostname }}/{{ inventory_hostname }}.key
         dest={{ cert_key_path }} backup=yes
         owner=root group=root mode=0400
-  when: cert_dir is defined and requires_cert == 'True'
+  when: cert_dir is defined and requires_cert | default(True) | bool == True
   tags: cert
 
 - name: Check if chain file exists in private_files


### PR DESCRIPTION
Some bug fixes for the Apache role focused on certificate transfer.

* [X] We need to **ensure** that the backup directory exists **before** transferring files there.
* [X] Fixed the old way of evaluating a boolean variable. 
_With existing code and using Ansible v**2.9.11**, the `requires_cert` variable wasn't evaluated correctly._