### PR TITLE
Use new apache role and add tags

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -106,8 +106,9 @@
 - hosts: swagger
   become: yes
   roles:
-    - { role: httpd, tags: httpd }
-    - { role: swagger }
+    - { role: commons, task: cert, tags: swagger_deploy }
+    - { role: apache, tags: swagger_deploy }
+    - { role: swagger, tags: [swagger_deploy, swagger_update] }
 
 - hosts: c_cluster
   become: yes


### PR DESCRIPTION
The following PR introduces the following changes.
- Use the new apache role for apache set up
- Use tags for a more convenient installation when we update just the swagger files