### PR TITLE
Fix percona mongodb probe.

### DIFF
--- a/roles/commons/tasks/repos.yml
+++ b/roles/commons/tasks/repos.yml
@@ -25,7 +25,7 @@
   copy: src=etc/yum.repos.d/percona-original-release.repo
         dest=/etc/yum.repos.d/percona-original-release.repo backup=no
         owner=root group=root mode=0644
-  when: repo_mongo_4x is defined or repo_mongo is defined
+  when: repo_mongo_4x or repo_mongo
   tags:
     - repo_mongodb
     - icinga_mongodb_agent
@@ -34,7 +34,7 @@
   copy: src=etc/yum.repos.d/percona-prel-release.repo
         dest=/etc/yum.repos.d/percona-prel-release.repo backup=no
         owner=root group=root mode=0644
-  when: repo_mongo_4x is defined or repo_mongo is defined
+  when: repo_mongo_4x or repo_mongo
   tags:
     - repo_mongodb
     - icinga_mongodb_agent
@@ -43,7 +43,7 @@
   copy: src=etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY
         dest=/etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY backup=no
         owner=root group=root mode=0644
-  when: repo_mongo_4x is defined or repo_mongo is defined
+  when: repo_mongo_4x or repo_mongo
   tags:
     - repo_mongodb
     - icinga_mongodb_agent

--- a/roles/icinga_agent/tasks/common_RedHat.yml
+++ b/roles/icinga_agent/tasks/common_RedHat.yml
@@ -56,5 +56,5 @@
     name: percona-nagios-plugins
     state: latest
   tags: icinga_mongodb_agent
-  when: repo_mongo_4x is defined or repo_mongo is defined
+  when: repo_mongo_4x or repo_mongo
   notify: Restart Icinga 2 service.


### PR DESCRIPTION
We need to install `percona` repositories and `percona-nagios-plugins` only when : 
`repo_mongo_4x == True   or  repo_mongo == True`
These variables are set to `False` by **default** ( is defined ) : https://github.com/ARGOeu/argo-ansible/blob/devel/roles/commons/defaults/main.yml#L27-L28