### PR TITLE
ARGO-2895 AMS devel mongodb backup

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -71,7 +71,6 @@
 - hosts: authn
   become: yes
   roles:
-    - { role: mongodb }
     - { role: argo-api-authn, task: authn-setup }
     - { role: argo-api-authn, task: python-env-setup }
     - { role: argo-api-authn, task: ams-create-users-gocdb-script }

--- a/roles/mongodb/README.md
+++ b/roles/mongodb/README.md
@@ -6,31 +6,29 @@ MongoDB role sets up mongodb
 Requirements
 ------------
 
-You will need to have the repo `mongodb-org-3.2` on the host.
-
 Role Variables
 --------------
-mongo_bind_interfaces: 127.0.0.1 # A Comma separated list of ips(interfaces) mongo should bind to
-mongo_replicated: false # If set to true mongodb will be deployed in a replicated fashion
-mongo_repo: # Set to mongodb-org-3.2 to install mongo-3.2 or mongodb-org-4.0 to install mongodb 4.0
-            # If you want to install mongodb-org-3.2 you should set repo_mongo:yes in commons role
-            # If you want to install mondodb-org-4.0 you should set repo_mongo_4x:yes in commons role
+* `mongo_bind_interfaces` : 127.0.0.1 # A Comma separated list of ips(interfaces) mongo should bind to
 
-Selecting MongoDB 3.2 or 4.0
-----------------------------
-This role supports the installation of MongoDB 3.2 or MongoDB 4.0 versions
-To prepare the deployment for MongoDB 3.2 you should:
- - Set variable `repo_mongo` to  `yes` in role commons 
- - Set variable `mongo_repo` to `mongodb-org-3.2` in this role
-To prepare the deployment for MongoDB 4.0 you should:
- - Set variable `repo_mongo_4x` to `yes` in role commons 
- - Set variable `mongo_repo` to `mongodb-org-4.0` in this role
+* `mongo_replicated` : false # If set to true mongodb will be deployed in a replicated fashion
+
+* `mongo_repo` : # Set to `mongodb-org-3.2` to install `mongo-3.2` or `mongodb-org-4.0` to install `mongodb 4.0`
+
+> * If you want to install **mongodb-org-3.2** you should set `repo_mongo:yes` in **commons** role
+
+ > * If you want to install **mondodb-org-4.0** you should set `repo_mongo_4x:yes` in **commons** role
+
+ * `mongo_backup_scripts_location` : variable for the location of the back up script
+
+ * `mongo_replica_set_name` :  variable that controls the name of the replica set
+
+ * `mongo_backup_dbs` : list variable that names the mongo databases that we want to backup.
 
 Dependencies
 ------------
 
 You need to specify the ansible inventory group that will consist your cluster
-- cluster_group: mongo_cluster
+- e.g. mongo_cluster_group: mongo_private_cluster_devel
 
 You need for each host to set up the following variable for the private interface
 private:

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -3,7 +3,13 @@
 
 # Comma separated list of IPs mongo service should bind to
 mongo_bind_interfaces: 127.0.0.1
+mongo_port: 27017
 mongo_replicated: false
 mongo_log_rotate: false
 is_mongo_host: false
 mongo_repo: mongodb-org-3.2
+mongo_backup_scripts_location: /opt/mongobackup/
+mongo_replica_set_name: rs0
+mongo_backup_dbs:
+  - argo_auth
+  - argo_msg

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -11,7 +11,7 @@
     - mongodb-org
     - mongodb-org-server
     - git
-    
+
 - name: install motop
   pip:
     name: git+https://github.com/tart/motop.git
@@ -33,8 +33,6 @@
     - mongo_install
   notify: restart mongo
 
-
-
 - name: Increase soft nproc limits
   copy:
     src: etc/security/limits.d/99-mongodb-nproc.conf
@@ -55,25 +53,25 @@
   template: dest="/tmp/db_init_rs.js" owner=root group=root mode=640 src=db_init_rs.js.j2
   tags:
     - mongo_replication
-  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+  when: mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname
 
 - name: Run init roles script
   shell: mongo < /tmp/db_init_rs.js
   tags:
     - mongo_replication
-  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+  when: mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname
 
 - name: Move rs add members script
   template: dest="/tmp/db_rs_members.js" owner=root group=root mode=640 src=db_rs_members.js.j2
   tags:
     - mongo_replication
-  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+  when: mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname
 
 - name: Run rs add members script
   shell: mongo < /tmp/db_rs_members.js
   tags:
     - mongo_replication
-  when: mongo_replicated == true and groups[cluster_group][0] == inventory_hostname
+  when: mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname
 
 - name: Transfer mongo rotate bash script
   copy:
@@ -94,3 +92,33 @@
     job: "/root/mongo_rotate.sh"
     cron_file: mongo_rotate
   when: mongo_log_rotate == true
+
+- name: Ensures mongodb backup directory for script(s) exists
+  file:
+    path: "{{mongo_backup_scripts_location}}"
+    state: directory
+  tags:
+    - mongo_backup
+  when: (mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname) or mongo_replicated == false
+
+- name: Move MongoDB backup script
+  template:
+    dest: "{{ mongo_backup_scripts_location }}mongo_backup.sh"
+    owner: root
+    group: root
+    mode: 0755
+    src: mongodb_backup.sh.j2
+  tags:
+    - mongo_backup
+  when: (mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname) or mongo_replicated == false
+
+- name: Set up cron job for mongo backup script
+  cron:
+    cron_file: mongodb_backup
+    name: "Set up cron job for mongo backup script"
+    user: root
+    special_time: daily
+    job: "{{ mongo_backup_scripts_location }}mongo_backup.sh"
+  tags:
+    - mongo_backup
+  when: (mongo_replicated == true and groups[mongo_cluster_group][0] == inventory_hostname) or mongo_replicated == false

--- a/roles/mongodb/templates/db_rs_members.js.j2
+++ b/roles/mongodb/templates/db_rs_members.js.j2
@@ -7,13 +7,13 @@
 {% if hostvars[host]['is_arbiter'] is defined %}
 
 {% if hostvars[host]['is_arbiter'] == 'True' %}
-rs.addArb("{{hostvars[host]['private']['hostname']}}:27017")
+rs.addArb("{{hostvars[host]['private']['hostname']}}:{{mongo_port}}")
 {% else  %}
-rs.add("{{hostvars[host]['private']['hostname']}}:27017")
+rs.add("{{hostvars[host]['private']['hostname']}}:{{mongo_port}}")
 {% endif %}
 
 {% else  %}
-rs.add("{{hostvars[host]['private']['hostname']}}:27017")
+rs.add("{{hostvars[host]['private']['hostname']}}:{{mongo_port}}")
 {% endif %}
 
 {% endif %}

--- a/roles/mongodb/templates/mongodb_backup.sh.j2
+++ b/roles/mongodb/templates/mongodb_backup.sh.j2
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+TIMESTAMP=`date +%FT%H:00`
+MONGODUMP_PATH="/usr/bin/mongodump"
+BACKUPS_DIR="/root/{{inventory_hostname}}-mongo-data"
+
+REPLSET_URI="{{mongo_replica_set_name}}/{% for host in groups[mongo_cluster_group] %}{% if hostvars[host]['private']['hostname'] is defined %}{{ hostvars[host]['private']['hostname'] }}{% else %}{{ hostvars[host].ansible_default_ipv4.address }}{% endif %}:{{mongo_port}}{% if not loop.last %},{% endif %}{% endfor %}"
+
+DATABASES=(
+  {% for host in mongo_backup_dbs %}
+    {{ host }}
+  {% endfor %}
+)
+
+for DB_NAME in "${DATABASES[@]}"; do
+  BACKUP_NAME="$DB_NAME-$TIMESTAMP"
+  mkdir -p $BACKUPS_DIR/$DB_NAME
+  $MONGODUMP_PATH --host $REPLSET_URI --db $DB_NAME --gzip --archive=$BACKUPS_DIR/$DB_NAME/$BACKUP_NAME.archive
+done


### PR DESCRIPTION
Introduce some new tasks that will take care of taking regular backups of the mongodb databases that we have in the devel cluster.

Introduce the backup script that can run for multiple databases.
Introduce a new variable, mongo_cluster_group specifically for grouping mongodb nodes.

mongo_backup_scripts_location variable for the location of the back up script
mongo_replica_set_name variable that controls the name of the replica set
mongo_backup_dbs: list variable that names the mongo databases that we want to backup.