### PR TITLE
Separate directory for rsyslog certificates.

### DIFF
--- a/roles/commons/defaults/main.yml
+++ b/roles/commons/defaults/main.yml
@@ -21,6 +21,7 @@ ca_path_bundle: /etc/pki/tls/certs/ca-bundle.crt
 # create the cert dir and move the cert and key
 # can be set to false if no cert/key is needed
 requires_cert: true
+rsyslog_cert_dir: "{{ cert_dir }}rsyslog-client-certs/"
 
 # defaults for role repos
 repo_enabled_argo: argo-devel  # from which repo to get the packages (argo-devel or argo-prod)

--- a/roles/commons/tasks/rsyslog.yml
+++ b/roles/commons/tasks/rsyslog.yml
@@ -24,21 +24,27 @@
   notify: restart rsyslog
 
 
+- name: Create {{ rsyslog_cert_dir }} if not exists
+  file: dest={{ rsyslog_cert_dir }} state=directory
+        owner=root group=root mode=0755
+  tags: rsyslog_conf
+
+
 - name: Copy rsyslog certificates [crt] (1/3)
   copy: src=private_files/star.argo.grnet.gr/star.argo.grnet.gr.crt
-        dest={{ cert_dir }} backup=yes
+        dest={{ rsyslog_cert_dir }}rsyslog.crt backup=yes
         owner=root group=root mode=0644
   tags: rsyslog_conf
 
 - name: Copy rsyslog certificates [key] (2/3)
   copy: src=private_files/star.argo.grnet.gr/star.argo.grnet.gr.key
-        dest={{ cert_dir }} backup=yes
+        dest={{ rsyslog_cert_dir }}rsyslog.key backup=yes
         owner=root group=root mode=0400
   tags: rsyslog_conf
 
 - name: Copy rsyslog certificates [chain] (3/3)
   copy: src=private_files/star.argo.grnet.gr/star.argo.grnet.gr_CHAIN_cert.crt
-        dest={{ cert_dir }} backup=yes
+        dest={{ rsyslog_cert_dir }}rsyslog_chain.crt backup=yes
         owner=root group=root mode=0400
   tags: rsyslog_conf
 
@@ -60,6 +66,5 @@
   tags:
     - rsyslog_conf
     - rsyslog_check
-
 
 

--- a/roles/commons/templates/50_client_remote.conf.j2
+++ b/roles/commons/templates/50_client_remote.conf.j2
@@ -1,8 +1,8 @@
 $DefaultNetstreamDriver gtls
 # certificate files
-$DefaultNetstreamDriverCAFile /etc/grid-security/star.argo.grnet.gr_CHAIN_cert.crt
-$DefaultNetstreamDriverCertFile /etc/grid-security/star.argo.grnet.gr.crt
-$DefaultNetstreamDriverKeyFile /etc/grid-security/star.argo.grnet.gr.key
+$DefaultNetstreamDriverCAFile {{ rsyslog_cert_dir }}rsyslog_chain.crt
+$DefaultNetstreamDriverCertFile {{ rsyslog_cert_dir }}rsyslog.crt
+$DefaultNetstreamDriverKeyFile {{ rsyslog_cert_dir }}rsyslog.key
 
 
 #$ModLoad imtcp  # TCP listener


### PR DESCRIPTION
To be as safe as possible, we will transfer the certificates for rsyslog client to the remote machines in a **completely separate directory** and with a very **specific name**.

So, by default we will have the following results:


* `/etc/rsyslog.d/50_client_remote.conf`
```
$DefaultNetstreamDriver gtls
# certificate files
$DefaultNetstreamDriverCAFile /etc/grid-security/rsyslog-client-certs/rsyslog_chain.crt
$DefaultNetstreamDriverCertFile /etc/grid-security/rsyslog-client-certs/rsyslog.crt
$DefaultNetstreamDriverKeyFile /etc/grid-security/rsyslog-client-certs/rsyslog.key


#$ModLoad imtcp  # TCP listener
$ActionSendStreamDriverAuthMode x509/name
$ActionSendStreamDriverPermittedPeer *.argo.grnet.gr
$ActionSendStreamDriverMode 1 # run driver in TLS-only mode


*.* @@rsyslog.argo.grnet.gr:6514;RSYSLOG_ForwardFormat
```



* Certificates directories:
```
/etc/grid-security/
└── rsyslog-client-certs
    ├── rsyslog_chain.crt
    ├── rsyslog.crt
    └── rsyslog.key
```


* Rsyslog client status
```
systemctl status rsyslog -l
● rsyslog.service - System Logging Service
   Loaded: loaded (/usr/lib/systemd/system/rsyslog.service; enabled; vendor preset: enabled)
   Active: active (running) since Thu 2021-02-11 12:32:22 EET; 13min ago
     Docs: man:rsyslogd(8)
           http://www.rsyslog.com/doc/
 Main PID: 31116 (rsyslogd)
   CGroup: /system.slice/rsyslog.service
           └─31116 /usr/sbin/rsyslogd -n

Feb 11 12:32:22 example systemd[1]: Starting System Logging Service...
Feb 11 12:32:22 example rsyslogd[31116]:  [origin software="rsyslogd" swVersion="8.24.0-57.el7_9" x-pid="31116" x-info="http://www.rsyslog.com"] start
Feb 11 12:32:22 example systemd[1]: Started System Logging Service.
```