### PR TITLE
ARGO-2975 ams ansible role: update push_worker init template

### DIFF
--- a/roles/ams/templates/db_init_pushworker.js.j2
+++ b/roles/ams/templates/db_init_pushworker.js.j2
@@ -1,13 +1,23 @@
 use {{ams_store_db}}
 
 db.users.update(
-{"token": "{{ams_push_worker_token}}"},
-{"$set":
-  {
-    "uuid":"{{ams_push_worker_uuid}}",
-    "name": "push_worker_0",
-    "email": "argo-ops@lists.grnet.gr",
-    "projects": [],
-    "service_roles": ["push_worker"]}
+{
+  "token": "{{ams_push_worker_token}}"
 },
-{"upsert":"true"})
+{
+  "$set":{
+      "uuid":"{{ams_push_worker_uuid}}",
+      "name": "push_worker_0",
+      "email": "argo-ops@lists.grnet.gr",
+      "modified_on": new Date(),
+      "service_roles": ["push_worker"]
+    },
+    "$setOnInsert":{
+      "created_on": new Date(),
+      "projects":[]
+    }
+  },
+{
+  "upsert":"true"
+}
+)


### PR DESCRIPTION
Update the push_worker init template to only initialize the projects empty array when being inserted for the first time.
Otherwise, every time we run the task, the push worker gets emptied from its projects.
Complementary also added valid ways to update the created_on and modified_on fields.