### PR TITLE
ARGO-3061 authn role: Install the ldap prerequisites

### DIFF
--- a/roles/argo-api-authn/tasks/python-env-setup.yml
+++ b/roles/argo-api-authn/tasks/python-env-setup.yml
@@ -29,6 +29,15 @@
    name: git
   tags: authn_env_install
 
+- name: Install ldap utility
+  yum:
+   name: '{{ item }}'
+   state: present
+  loop:
+   - gcc
+   - openldap-devel
+  tags: authn_env_install
+
 - name: Clear any previous authn-env directory
   file:
    path: "{{ virtual_env_installation }}/authn-env"


### PR DESCRIPTION
System prerequisites in order to install python-ldap=3.3.1 that will be added to the scripts environment