### PR TITLE
DEVOPS-415: Apache/enable disable modules

### DIFF
--- a/roles/apache/README.md
+++ b/roles/apache/README.md
@@ -88,6 +88,17 @@ Execution with `--ask-become-pass`
 ansible-playbook --ask-become-pass -i devel -l apache argo-ansible/install.yml -t apache_install -u root -vv
 ```
 
+### Apache (httpd) modules
+
+If you want to enable/disable some extra apache module, you can use the following list variables:
+
+* `httpd_extra_system_packages` : System packages that required for the extra apache modules.
+* `httpd_mods_disabled` : The name of the apache module where you want to disable.
+* `httpd_mods_enabled`  : The name of the apache module where you want to enable.
+
+* See `defaults/main.yml` for usage examples.
+
+
 License
 -------
 

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -15,3 +15,28 @@ backup_dir: /var/apache_backup
 #      AllowOverride None
 #      Require all granted
 #    </Directory>
+
+#httpd_extra_system_packages:
+#  - httpd-tools
+#  - httpd-devel
+#  - openssl
+#  - mod_ssl
+#  - mod_wsgi
+#  - mod_geoip
+#  - mod_gnutls
+#  - mod_fcgid
+#  - mod_security
+
+#httpd_mods_disabled:
+#  - mpm_prefork
+#  - gnutls
+
+#httpd_mods_enabled:
+#  - rewrite
+#  - ssl
+#  - headers
+#  - http2
+#  - env
+#  - dir
+#  - mime
+

--- a/roles/apache/tasks/install.yml
+++ b/roles/apache/tasks/install.yml
@@ -7,3 +7,54 @@
       - mod_ssl
     state: latest
   tags: apache
+
+
+- name: Install Apache (httpd) extra system packages
+  yum:
+    name: "{{ httpd_extra_system_packages }}"
+    state: latest
+  when: httpd_extra_system_packages is defined
+  notify:
+    - restart httpd
+  tags:
+    - apache
+    - apache_extra
+
+
+## Disable modules
+
+- name: Disable Apache (httpd) modules
+  apache2_module:
+    state: absent
+    name: "{{ item }}"
+    ignore_configcheck: True
+  with_items: "{{ httpd_mods_disabled }}"
+  when: httpd_mods_disabled is defined
+  notify:
+    - restart httpd
+  tags:
+    - apache
+    - apache_extra
+    - apache_modules_disabled
+
+
+## Enable modules
+
+- name: Enable Apache (httpd) modules
+  apache2_module:
+    state: present
+    name: "{{ item }}"
+    ignore_configcheck: True
+  register: enable_module
+  with_items: "{{ httpd_mods_enabled }}"
+  when: httpd_mods_enabled is defined
+  notify:
+    - restart httpd
+  ignore_errors: yes
+  tags:
+    - apache
+    - apache_extra
+    - apache_modules_enabled
+
+
+


### PR DESCRIPTION
Now we can also install and enable/disable apache (httpd) modules only using the following list variables:

* [X] `httpd_extra_system_packages`
* [X] `httpd_mods_disabled`
* [X] `httpd_mods_enabled`