### PR TITLE
Fix: Add quotes.

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -33,7 +33,7 @@ haproxy_listen_stats_port: 9000
 
 
 ## frontend
-haproxy_frontend: {{ inventory_hostname }}
+haproxy_frontend: "{{ inventory_hostname }}"
 haproxy_frontend_timeout_http_request: "10s"
 haproxy_frontend_port_bind_ssl: 443
 haproxy_frontend_port_bind: 80


### PR DESCRIPTION
* [X] Small fix `{{ inventory_hostname }}` ==> `"{{ inventory_hostname }}"`
------------------
Jenkins jobs: 
* https://jenkins.einfra.grnet.gr/job/ARGO-utils/job/deploy-gr.grnet.eseal/27/ :x: 
* https://jenkins.einfra.grnet.gr/job/ARGO-utils/job/deploy-gr.grnet.eseal/28/ :x: 