### PR TITLE
Set until argument after retries

### DIFF
--- a/roles/eseal/tasks/main.yml
+++ b/roles/eseal/tasks/main.yml
@@ -185,10 +185,11 @@
     validate_certs: false
     status_code: 400
     return_content: yes
-  retries: 3
-  delay: 3
+  retries: 5
+  delay: 5
   register: this
   failed_when: "'Malformed JSON body' not in this.content"
+  until: this is not failed
   tags:
     - eseal
     - eseal:check
@@ -202,10 +203,11 @@
     validate_certs: false
     status_code: 400
     return_content: yes
-  retries: 3
-  delay: 3
+  retries: 5
+  delay: 5
   register: this
   failed_when: "'Malformed JSON body' not in this.content"
+  until: this is not failed
   tags:
     - eseal
     - eseal:check

--- a/roles/eseal/tasks/main.yml
+++ b/roles/eseal/tasks/main.yml
@@ -183,13 +183,14 @@
     url: "https://{{ inventory_hostname }}/api/v1/validation/validateDocument"
     method: POST
     validate_certs: false
-    status_code: 400
+    status_code:
+      - 200
+      - 400
     return_content: yes
   retries: 5
-  delay: 5
-  register: this
-  failed_when: "'Malformed JSON body' not in this.content"
-  until: this is not failed
+  delay: 10
+  register: validate
+  until: validate.status == 400
   tags:
     - eseal
     - eseal:check
@@ -201,13 +202,14 @@
     url: "https://{{ inventory_hostname }}/api/v1/signing/remoteSignDocument"
     method: POST
     validate_certs: false
-    status_code: 400
+    status_code:
+      - 200
+      - 400
     return_content: yes
   retries: 5
-  delay: 5
-  register: this
-  failed_when: "'Malformed JSON body' not in this.content"
-  until: this is not failed
+  delay: 10
+  register: sign
+  until: sign.status == 400
   tags:
     - eseal
     - eseal:check
@@ -221,7 +223,6 @@
   tags:
     - eseal
     - eseal:check
-
 
 
 


### PR DESCRIPTION
The until - retry is called `until loop` https://www.ansible.com/blog/ansible-tips-and-tricks-dealing-with-unreliable-connections-and-services and those arguments should be both present to be able to retry the command in the specific module.