### PR TITLE
DEVOPS-469 : Zookeeper & Kafka /etc/ configuration paths.

### DIFF
--- a/roles/kafka/tasks/config.yml
+++ b/roles/kafka/tasks/config.yml
@@ -30,6 +30,8 @@
     - kafka:user
 
 
+# Directories
+
 - name: "Create {{ kafka_log_dirs }} directory for Apache Kafka DATA if it does not exist"
   file:
     path: "{{ kafka_log_dirs }}"
@@ -46,6 +48,22 @@
     - kafka:disk
     - kafka:data_directory
     - kafka:create_data_directory
+
+
+- name: "Create  /etc/kafka/   directory for Apache config files if it does not exist"
+  file:
+    path: "/etc/kafka/conf"
+    state: directory
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: '0755'
+    recurse: yes
+  tags:
+    - kafka
+    - kafka:config
+    - kafka:install
+    - kafka:system
+    - kafka:config_directory
 
 
 - name: "Set appropriate ownership, group and permissions in {{ kafka_root }}"

--- a/roles/kafka/tasks/kafka.yml
+++ b/roles/kafka/tasks/kafka.yml
@@ -53,6 +53,27 @@
     - kafka:server:properties
 
 
+- name: "mv {{ kafka_conf_dir }}/* --> /etc/kafka/conf"
+  shell: "mv {{ kafka_conf_dir }}/* /etc/kafka/conf"
+  tags:
+    - kafka
+    - kafka:install
+    - kafka:config
+
+- name: "Create symbolic link {{ kafka_conf_dir }} --> /etc/kafka/conf"
+  file:
+    src: "/etc/kafka/conf"
+    path: "{{ kafka_conf_dir }}"
+    state: link
+    force: yes
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+  tags:
+    - kafka
+    - kafka:install
+    - kafka:config
+
+
 - name: Apache Kafka systemd service file
   template:
     src: etc/systemd/system/kafka.service.j2

--- a/roles/zookeeper/tasks/config.yml
+++ b/roles/zookeeper/tasks/config.yml
@@ -21,7 +21,7 @@
     group: "{{ zookeeper_group }}"
     create_home: no
     system: yes
-    comment: Apache Kafka user
+    comment: Apache Zookeeper user
   tags:
     - zookeeper
     - zookeeper:config
@@ -49,6 +49,20 @@
 - name: "Create {{ zookeeper_data }} directory for Apache Zookeeper DATA if it does not exist"
   file:
     path: "{{ zookeeper_data }}"
+    state: directory
+    owner: "{{ zookeeper_user }}"
+    group: "{{ zookeeper_group }}"
+    mode: '0755'
+  tags:
+    - zookeeper
+    - zookeeper:install
+    - zookeeper:config
+    - zookeeper:data
+
+
+- name: "Create  /etc/zookeeper/conf   directory for Apache Zookeeper config files if it does not exist"
+  file:
+    path: "/etc/zookeeper/conf"
     state: directory
     owner: "{{ zookeeper_user }}"
     group: "{{ zookeeper_group }}"

--- a/roles/zookeeper/tasks/zookeeper.yml
+++ b/roles/zookeeper/tasks/zookeeper.yml
@@ -127,6 +127,27 @@
     - zookeeper:config
 
 
+- name: "mv {{ zookeeper_conf_dir }}/* --> /etc/zookeeper/conf"
+  shell: "mv {{ zookeeper_conf_dir }}/* /etc/zookeeper"
+  tags:
+    - zookeeper
+    - zookeeper:install
+    - zookeeper:config
+
+- name: "Create symbolic link {{ zookeeper_conf_dir }} --> /etc/zookeeper/conf"
+  file:
+    src: "/etc/zookeeper/conf"
+    path: "{{ zookeeper_conf_dir }}"
+    state: link
+    force: yes
+    owner: "{{ zookeeper_user }}"
+    group: "{{ zookeeper_group }}"
+  tags:
+    - zookeeper
+    - zookeeper:install
+    - zookeeper:config
+
+
 - name: Apache Zookeeper systemd service file
   template:
     src: etc/systemd/system/zookeeper.service.j2


### PR DESCRIPTION
* [X] Apache Zookeeper & Apache Kafka configuration files in /etc/
* [X] Symbolic links from `/usr/lib/.../` to `/etc/.../`