### PR TITLE
Fix zookeeper logs and configuration.

### DIFF
--- a/roles/ams/templates/config.json.j2
+++ b/roles/ams/templates/config.json.j2
@@ -1,7 +1,7 @@
 {
   "bind_ip":"{{ams_bind_ip}}",
   "port":{{ams_port}},
-  "zookeeper_hosts":[{% for host in groups[zookeeper_group] %}{% if hostvars[host]['is_zoo_host'] is defined %}{% if hostvars[host]['is_zoo_host'] | bool == True %}"{{hostvars[host]['private']['hostname']}}:2181"{% if not loop.last %},{% endif %}{% endif %}{% endif %}{% endfor %} ],
+  "zookeeper_hosts":[{% for host in groups[zookeeper_cluster_group] %}{% if hostvars[host]['is_zoo_host'] is defined %}{% if hostvars[host]['is_zoo_host'] | bool == True %}"{{hostvars[host]['private']['hostname']}}:2181"{% if not loop.last %},{% endif %}{% endif %}{% endif %}{% endfor %} ],
   "kafka_znode":"{{ams_kafka_znode}}",
   "store_host":"{{ams_store_host}}",
   "store_db":"{{ams_store_db}}",

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -132,7 +132,7 @@ log.cleaner.enable=false
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
 # root directory for all kafka znodes.
-zookeeper.connect={% for host in groups[zookeeper_group] %}{% if hostvars[host]['is_zoo_host'] is defined %}{% if hostvars[host]['is_zoo_host'] | bool == True %}{{hostvars[host]['private']['hostname']}}:2181{% if not loop.last %},{% endif %}{% endif %}{% endif %}{% endfor %}
+zookeeper.connect={% for host in groups[zookeeper_cluster_group] %}{% if hostvars[host]['is_zoo_host'] is defined %}{% if hostvars[host]['is_zoo_host'] | bool == True %}{{hostvars[host]['private']['hostname']}}:2181{% if not loop.last %},{% endif %}{% endif %}{% endif %}{% endfor %}
 
 
 

--- a/roles/zookeeper/templates/zoo.cfg.j2
+++ b/roles/zookeeper/templates/zoo.cfg.j2
@@ -27,7 +27,7 @@ dataDir={{zookeeper_data}}
 # the port at which the clients will connect
 clientPort=2181
 # the directory where the transaction logs are stored.
-dataLogDir={{zookeeper_logs}}
+dataLogDir={{zookeeper_data}}
 
 {% if cluster_group is defined %}
 {% for host in groups[cluster_group] %}


### PR DESCRIPTION
* [X] `zookeeper_group`  ==> `zookeeper_cluster_group` ( _https://pastebin.com/raw/tWfbKMTC `Ensure group`_ )
* [X] `dataLogDir` == `dataDir`


The variable `zookeeper_group` already exists in the [zookeeper role](https://github.com/ARGOeu/argo-ansible/tree/devel/roles/zookeeper). 

* https://github.com/ARGOeu/argo-ansible/blob/e071c4d2ea347a7a986ff99a7374cc69763a5bfb/roles/zookeeper/tasks/config.yml#L7-L30

* https://github.com/ARGOeu/argo-ansible/blob/e071c4d2ea347a7a986ff99a7374cc69763a5bfb/roles/zookeeper/defaults/main.yml#L40-L41

and in https://github.com/grnet/argo-ansible-deploy/blob/43bce4ecd45cf38759939813722dfe89cefe0b15/group_vars/ams_cluster#L12

So, in order to avoid confusion, I renamed this variable to `zookeeper_cluster_group`.


----------

* :link: https://github.com/grnet/argo-ansible-deploy/pull/336 :warning: 
