### PR TITLE
Improvements for different Icinga master setups.

### DIFF
--- a/roles/icinga_agent/README.md
+++ b/roles/icinga_agent/README.md
@@ -14,8 +14,10 @@ This role needs to be executed after `commons/firewall` role, so that the firewa
 Role Variables
 --------------
 
-* `defaults/icinga_master_domain` : The domain name of Icinga master.
+* `icinga_master_domain` (**mandatory**) : The domain name of Icinga master.
+* `client_pki_ticket_token` (**mandatory**) : The password of `client-pki-ticket` **API user** from master (`/etc/icinga2/conf.d/api-users.conf`).
 * `group_vars/source` : The IPv4 address of the Icinga master, so as to allow communication with it from firewall.
+
 
 Example Playbook
 ----------------
@@ -26,6 +28,15 @@ Example Playbook
          - { role: icinga, tags: deploy_icinga_agent }
 ```
 
+
+Example Inventory
+-----------------
+```
+[icinga_agent]
+node-agent    ansible_user=root
+```
+
+* Example 1:
 ```
 ansible-playbook -i production argo-ansible/install.yml --list-hosts --list-tasks
 
@@ -129,6 +140,31 @@ RUNNING HANDLER [icinga : Restart Icinga 2 service.] ***************************
 changed: [snf-TEST.ok.net]
 ```
 </details>
+
+
+* Example 2:
+```
+ansible-playbook -i production argo-ansible/install.yml \
+-e "icinga_master_domain=icinga.master.example.com client_pki_ticket_token=abcd123" \
+--ssh-common-args='-o StrictHostKeyChecking=no' -vv --list-hosts --list-tasks
+
+playbook: argo-ansible/install.yml
+
+  play #1 (icinga_agent): icinga_agent	TAGS: []
+    pattern: ['icinga_agent']
+    hosts (1):
+     icinga-agent.example.com
+    tasks:
+      icinga_agent : Include common Icinga tasks for Master & Agent nodes.	TAGS: [deploy_icinga_agent]
+      icinga_agent : Installing some utils for Icigna	TAGS: [deploy_icinga_agent]
+      icinga_agent : Set Agent script.	TAGS: [deploy_icinga_agent]
+      icinga_agent : Get ICINGA2_CA_TICKET from Icinga master	TAGS: [deploy_icinga_agent]
+      icinga_agent : Execute Agent script	TAGS: [deploy_icinga_agent]
+      icinga_agent : Restart Icinga 2 service.	TAGS: [deploy_icinga_agent]
+      icinga_agent : Don't forget to config your firewall!	TAGS: [deploy_icinga_agent]
+```
+
+
 
 License
 -------

--- a/roles/icinga_agent/defaults/main.yml
+++ b/roles/icinga_agent/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for icinga
 
 icinga_master_domain: "icinga.argo.grnet.gr"
+#client_pki_ticket_token: "Token from /etc/icinga2/conf.d/api-users.conf: ApiUser client-pki-ticket"

--- a/roles/icinga_agent/handlers/main.yml
+++ b/roles/icinga_agent/handlers/main.yml
@@ -2,7 +2,7 @@
 # handlers file for icinga
 
 
-- name: Restart Icinga 2 service.
+- name: Restart Icinga 2 service
   service:
     name: icinga2
     state: restarted

--- a/roles/icinga_agent/tasks/agent.yml
+++ b/roles/icinga_agent/tasks/agent.yml
@@ -9,39 +9,51 @@
     owner: root
     group: root
     mode: '0755'
+  tags:
+    - icinga_agent
+    - script
 
+# TODO:
+#- name: Delete previous certificates ( if exists )
+#  shell: rm /var/lib/icinga2/certs/{{ inventory_hostname }}.*
 
 - name: Get ICINGA2_CA_TICKET from Icinga master
   shell: |
-          sed -i "/ICINGA2\_CA\_TICKET/s/'.*'/'$(curl -k -s -u client-pki-ticket:kcjRc8ddPgJ9E64px9Y= -H 'Accept: application/json' -X POST 'https://{{ icinga_master_domain  }}:5665/v1/actions/generate-ticket' -d '{ "cn": "{{ inventory_hostname }}" }' | jq '.results[0] .ticket' --raw-output)'/" icinga2-agent-kickstart.bash
+          sed -i "/ICINGA2\_CA\_TICKET/s/'.*'/'$(curl -k -s -u client-pki-ticket:{{ client_pki_ticket_token }} -H 'Accept: application/json' -X POST 'https://{{ icinga_master_domain }}:5665/v1/actions/generate-ticket' -d '{ "cn": "{{ inventory_hostname }}" }' | jq '.results[0] .ticket' --raw-output)'/" icinga2-agent-kickstart.bash
   args:
     chdir: /tmp/
+  tags:
+    - icinga_agent
+    - ca_ticket
+    - agent_kickstart
 
 - name: Execute Agent script
   shell: ICINGA2_UPDATE_CONFIG=1 ./icinga2-agent-kickstart.bash
   args:
     chdir: /tmp/
-
-
-- name: Restart Icinga 2 service.
-  service:
-    name: icinga2
-    state: restarted
+  notify: Restart Icinga 2 service
+  tags:
+    - icinga_agent
+    - ca_ticket
+    - agent_kickstart
 
 
 - name: Don't forget to config your firewall!
   debug:
     msg:
     - iptables/ip6tables
-    - -A INPUT -p tcp -s 83.212.76.0/32 --dport 5665 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+    - -A INPUT -p tcp -s {{ lookup('dig', icinga_master_domain ) }}/32 --dport 5665 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
     - UFW
-    - ufw allow from 83.212.76.0/32 to any port 5665 proto tcp
+    - ufw allow from {{ lookup('dig', icinga_master_domain ) }}/32 to any port 5665 proto tcp
     - Firewalld.
     - firewall-cmd --new-zone=icinga --permanent
     - firewall-cmd --reload
-    - firewall-cmd --zone=icinga --add-source=83.212.76.0/32
+    - firewall-cmd --zone=icinga --add-source={{ lookup('dig', icinga_master_domain ) }}/32
     - firewall-cmd --zone=icinga --add-port=5665/tcp
     - firewall-cmd --runtime-to-permanent
     - firewall-cmd --get-active-zones
+  tags:
+    - icinga_agent
+    - firewall_message
 
  

--- a/roles/icinga_agent/tasks/common_RedHat.yml
+++ b/roles/icinga_agent/tasks/common_RedHat.yml
@@ -32,7 +32,9 @@
 
 - name: Install Icinga 2 Check Plugins.
   yum:
-    name: nagios-plugins-all
+    name:
+      - nagios-plugins-all
+      - nagios-plugins-check-updates
     state: latest
 
 


### PR DESCRIPTION
* [X] Added `client_pki_ticket_token`
* [X] Update README.md
* [X] Add tags
* [X] Add icinga restart notifier instead of task
* [X] Fix firewall message in order to be more dynamic for all Icinga2 master domains

Now we can run icinga agent for different Icinga masters like bellow:

* Example 1:
```
ansible-playbook -i production argo-ansible/install.yml \
-e "icinga_master_domain=icinga-1.master.example.com client_pki_ticket_token=123456789" \
--ssh-common-args='-o StrictHostKeyChecking=no' -vv
```

* Example 2:
```
ansible-playbook -i production argo-ansible/install.yml \
-e "icinga_master_domain=icinga-2.master.example.com client_pki_ticket_token=abcdef" \
--ssh-common-args='-o StrictHostKeyChecking=no' -vv
```

