### PR TITLE
Update icinga2-agent-kickstart

### DIFF
--- a/roles/icinga_agent/README.md
+++ b/roles/icinga_agent/README.md
@@ -38,9 +38,9 @@ node-agent    ansible_user=root
 
 * Example 1:
 ```
-ansible-playbook -i production argo-ansible/install.yml --list-hosts --list-tasks
+ansible-playbook -i production argo-ansible/icinga-agent.yml --list-hosts --list-tasks
 
-playbook: argo-ansible/install.yml
+playbook: argo-ansible/icinga-agent.yml
 
   play #1 (all): all    TAGS: []
     pattern: ['all']
@@ -144,11 +144,11 @@ changed: [snf-TEST.ok.net]
 
 * Example 2:
 ```
-ansible-playbook -i production argo-ansible/install.yml \
+ansible-playbook -i production argo-ansible/icinga-agent.yml \
 -e "icinga_master_domain=icinga.master.example.com client_pki_ticket_token=abcd123" \
 --ssh-common-args='-o StrictHostKeyChecking=no' -vv --list-hosts --list-tasks
 
-playbook: argo-ansible/install.yml
+playbook: argo-ansible/icinga-agent.yml
 
   play #1 (icinga_agent): icinga_agent	TAGS: []
     pattern: ['icinga_agent']

--- a/roles/icinga_agent/defaults/main.yml
+++ b/roles/icinga_agent/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
 # defaults file for icinga
 
-icinga_master_domain: "icinga.argo.grnet.gr"
-#client_pki_ticket_token: "Token from /etc/icinga2/conf.d/api-users.conf: ApiUser client-pki-ticket"
+#icinga_master_domain: "icinga.example.com"
+
+## Client-pki-ticket user & token from /etc/icinga2/conf.d/api-users.conf: ApiUser client-pki-ticket
+#client_pki_ticket_user: "ApiUser"
+#client_pki_ticket_token: "password"
+
+

--- a/roles/icinga_agent/tasks/agent.yml
+++ b/roles/icinga_agent/tasks/agent.yml
@@ -19,7 +19,7 @@
 
 - name: Get ICINGA2_CA_TICKET from Icinga master
   shell: |
-          sed -i "/ICINGA2\_CA\_TICKET/s/'.*'/'$(curl -k -s -u client-pki-ticket:{{ client_pki_ticket_token }} -H 'Accept: application/json' -X POST 'https://{{ icinga_master_domain }}:5665/v1/actions/generate-ticket' -d '{ "cn": "{{ inventory_hostname }}" }' | jq '.results[0] .ticket' --raw-output)'/" icinga2-agent-kickstart.bash
+          sed -i "/ICINGA2\_CA\_TICKET/s/'.*'/'$(curl -k -s -u {{ client_pki_ticket_user }}:{{ client_pki_ticket_token }} -H 'Accept: application/json' -X POST 'https://{{ icinga_master_domain }}:5665/v1/actions/generate-ticket' -d '{ "cn": "{{ inventory_hostname }}" }' | jq '.results[0] .ticket' --raw-output)'/" icinga2-agent-kickstart.bash
   args:
     chdir: /tmp/
   tags:

--- a/roles/icinga_agent/tasks/common_Debian.yml
+++ b/roles/icinga_agent/tasks/common_Debian.yml
@@ -38,7 +38,7 @@
   with_items:
     - "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free"
     - "deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free"
-  when: ansible_distribution_release == 'stretch'
+  when: ansible_distribution_release == 'stretch' or ansible_distribution_release == 'buster'
 
 
 
@@ -72,7 +72,7 @@
 
 - name: Configuration Syntax Highlighting using Vim.
   shell: vim-addon-manager -w install icinga2
-  notify: Restart Icinga 2 service.
+  notify: Restart Icinga 2 service
 
 
 

--- a/roles/icinga_agent/templates/icinga2-agent-kickstart.bash.j2
+++ b/roles/icinga_agent/templates/icinga2-agent-kickstart.bash.j2
@@ -81,6 +81,13 @@ elif check_command dpkg; then
     . /etc/default/icinga2
   fi
   ICINGA2_OSFAMILY=debian
+elif check_command apk; then
+  info "This should be a Alpine system"
+  if [ -e /etc/icinga2/icinga2.sysconfig ]; then
+    # shellcheck disable=SC1091
+    . /etc/icinga2/icinga2.sysconfig
+  fi
+  ICINGA2_OSFAMILY=alpine
 else
   fail "Could not determine your os type!"
 fi
@@ -100,6 +107,10 @@ debian)
   : "${ICINGA2_GROUP:=nagios}"
   ;;
 redhat)
+  : "${ICINGA2_USER:=icinga}"
+  : "${ICINGA2_GROUP:=icinga}"
+  ;;
+alpine)
   : "${ICINGA2_USER:=icinga}"
   : "${ICINGA2_GROUP:=icinga}"
   ;;
@@ -177,7 +188,7 @@ elif [ -z "${ICINGA2_DRYRUN}" ]; then
     --cert "${ICINGA2_SSLDIR}/${ICINGA2_NODENAME}.crt" \
     --trustedcert "${ICINGA2_SSLDIR}/trusted-master.crt" \
     --ca "${ICINGA2_SSLDIR}/ca.crt"
-  then "Could not retrieve final certificate from host ${ICINGA2_CA_NODE}"
+  then fail "Could not retrieve final certificate from host ${ICINGA2_CA_NODE}"
   fi
 else
   info "Would create certificates under ${ICINGA2_SSLDIR}, but in dry-run!"
@@ -275,7 +286,20 @@ if [ -z "${ICINGA2_DRYRUN}" ]; then
   "$ICINGA2_BIN" daemon -C
 
   echo "Please restart icinga2:"
-  echo "  systemctl restart icinga2"
+  case "$ICINGA2_OSFAMILY" in
+  debian)
+    echo "  systemctl restart icinga2"
+    ;;
+  redhat)
+    echo "  systemctl restart icinga2"
+    ;;
+  alpine)
+    echo "  rc-service icinga2 restart"
+    ;;
+  *)
+    fail "Unknown osfamily '$ICINGA2_OSFAMILY'!"
+    ;;
+  esac
 else
   output_code() {
     sed 's/^/    /m' <<<"$1"


### PR DESCRIPTION
* [X] Updated the auto generated `icinga2-agent-kickstart.bash`

Produced by a new Icinga2 installation.
* icinga2 `2.12.4-1`   ==> `2.13.1-1`
* Icinga Web 2 `2.8.2` ==> `2.9.3`
* director     `1.8.0` ==> `1.8.1`
* monitoring   `2.8.2` ==> `2.9.3`

* [X] Fixed some typos in README.
* [X] Added `buster` support for Debian GNU/Linux.
* [X] Added `client_pki_ticket_user` variable.

-----------------------------------------
Tested:
* CentOS Linux release 7.9.2009 (Core)  :heavy_check_mark: 
* Debian GNU/Linux 8.11 (jessie) :heavy_check_mark: 