### PR TITLE
Rsyslog client improvements.

### DIFF
--- a/roles/commons/tasks/rsyslog.yml
+++ b/roles/commons/tasks/rsyslog.yml
@@ -41,22 +41,50 @@
 
 
 - name: Copy rsyslog certificates [crt] (1/3)
-  copy: src=private_files/star.argo.grnet.gr/star.argo.grnet.gr.crt
-        dest={{ rsyslog_cert_dir }}rsyslog.crt backup=yes
-        owner=root group=root mode=0644
-  tags: rsyslog_conf
+  copy:
+    src: "private_files/{{ inventory_hostname }}/rsyslog-gnutls/rsyslog-cert.pem"
+    dest: "{{ rsyslog_cert_dir }}rsyslog.crt"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  notify: restart rsyslog
+  tags:
+    - rsyslog
+    - rsyslog_conf
+    - rsyslog_certs
+    - rsyslog_cert
 
 - name: Copy rsyslog certificates [key] (2/3)
-  copy: src=private_files/star.argo.grnet.gr/star.argo.grnet.gr.key
-        dest={{ rsyslog_cert_dir }}rsyslog.key backup=yes
-        owner=root group=root mode=0400
-  tags: rsyslog_conf
+  copy:
+    src: "private_files/{{ inventory_hostname }}/rsyslog-gnutls/rsyslog-key.pem"
+    dest: "{{ rsyslog_cert_dir }}rsyslog.key"
+    owner: root
+    group: root
+    mode: 0400
+    backup: yes
+  notify: restart rsyslog
+  tags:
+    - rsyslog
+    - rsyslog_conf
+    - rsyslog_certs
+    - rsyslog_key
 
-- name: Copy rsyslog certificates [chain] (3/3)
-  copy: src=private_files/star.argo.grnet.gr/star.argo.grnet.gr_CHAIN_cert.crt
-        dest={{ rsyslog_cert_dir }}rsyslog_chain.crt backup=yes
-        owner=root group=root mode=0400
-  tags: rsyslog_conf
+- name: Copy rsyslog certificates [CA] (3/3)
+  copy:
+    src: "private_files/{{ inventory_hostname }}/rsyslog-gnutls/rsyslog-ca.pem"
+    dest: "{{ rsyslog_cert_dir }}rsyslog_ca.crt"
+    owner: root
+    group: root
+    mode: 0400
+    backup: yes
+  notify: restart rsyslog
+  tags:
+    - rsyslog
+    - rsyslog_conf
+    - rsyslog_certs
+    - rsyslog_ca
+
 
 - meta: flush_handlers
 

--- a/roles/commons/templates/etc/rsyslog.d/50_client_remote.conf.j2
+++ b/roles/commons/templates/etc/rsyslog.d/50_client_remote.conf.j2
@@ -2,7 +2,7 @@
 
 global(
 DefaultNetstreamDriver="gtls"
-DefaultNetstreamDriverCAFile="{{ rsyslog_cert_dir }}rsyslog_chain.crt"
+DefaultNetstreamDriverCAFile="{{ rsyslog_cert_dir }}rsyslog_ca.crt"
 DefaultNetstreamDriverCertFile="{{ rsyslog_cert_dir }}rsyslog.crt"
 DefaultNetstreamDriverKeyFile="{{ rsyslog_cert_dir }}rsyslog.key"
 )


### PR DESCRIPTION
Improvements to be able to support different/general certificates.

Now, regardless of the certificate ( domain specific, star certificate etc.. ), all that is needed is to be placed with the following names:
* `private_files/{{ inventory_hostname }}/rsyslog-gnutls/rsyslog-cert.pem`
* `private_files/{{ inventory_hostname }}/rsyslog-gnutls/rsyslog-key.pem`
* `private_files/{{ inventory_hostname }}/rsyslog-gnutls/rsyslog-ca.pem`

* [X] Rsyslog certificates path/name.
* [X] Added more tags.
* [X] Added notifiers.


### Quick check example:
```
ansible-playbook -i devel argo-ansible/install.yml -vv --tags="repos, rsyslog_conf" --list-hosts --list-tasks
```