### PR TITLE
Commons: Rsyslog conf for fail2ban.

### DIFF
--- a/roles/commons/defaults/main.yml
+++ b/roles/commons/defaults/main.yml
@@ -21,8 +21,13 @@ ca_path_bundle: /etc/pki/tls/certs/ca-bundle.crt
 # create the cert dir and move the cert and key
 # can be set to false if no cert/key is needed
 requires_cert: true
+
+# Rsyslog
+#central_rsyslog:
+#  hostname: "rsyslog.example.com"
+#  port: "6514"
 rsyslog_cert_dir: "{{ cert_dir }}rsyslog-client-certs/"
-rsyslog_apache_logs: false
+rsyslog_fail2ban_logs: true
 
 # defaults for role repos
 repo_enabled_argo: argo-devel  # from which repo to get the packages (argo-devel or argo-prod)

--- a/roles/commons/tasks/fail2ban.yml
+++ b/roles/commons/tasks/fail2ban.yml
@@ -5,6 +5,7 @@
   template:
     src: etc/fail2ban/fail2ban.local.j2
     dest: /etc/fail2ban/fail2ban.local
+    backup: yes
     owner: root
     group: root
     mode: 0644
@@ -18,6 +19,7 @@
   template:
     src: etc/fail2ban/jail.local.j2
     dest: /etc/fail2ban/jail.local
+    backup: yes
     owner: root
     group: root
     mode: 0644

--- a/roles/commons/tasks/rsyslog.yml
+++ b/roles/commons/tasks/rsyslog.yml
@@ -24,12 +24,12 @@
   tags: rsyslog_conf
   notify: restart rsyslog
 
-- name: Rsyslog apache logs conf file
+- name: Rsyslog Fail2Ban logs conf file
   template:
-    src=etc/rsyslog.d/apache.log.conf.j2
-    dest=/etc/rsyslog.d/apache.log.conf backup=yes
+    src=etc/rsyslog.d/59_fail2ban.log.conf.j2
+    dest=/etc/rsyslog.d/59_fail2ban.log.conf backup=yes
     owner=root group=root mode=0644
-  when: rsyslog_apache_logs
+  when: rsyslog_fail2ban_logs
   tags: rsyslog_conf
   notify: restart rsyslog
 

--- a/roles/commons/templates/etc/rsyslog.d/59_fail2ban.log.conf.j2
+++ b/roles/commons/templates/etc/rsyslog.d/59_fail2ban.log.conf.j2
@@ -1,35 +1,34 @@
 # {{ ansible_managed }}
 
-# Send Apache logs.
+# Send Fail2Ban logs.
 ## https://www.rsyslog.com/doc/master/configuration/modules/imfile.html
 ## https://www.rsyslog.com/doc/master/configuration/actions.html
 ## https://www.rsyslog.com/doc/master/configuration/templates.html
 ## https://www.rsyslog.com/doc/master/concepts/queues.html
 ## https://www.rsyslog.com/doc/master/rainerscript/queue_parameters.html
 
-Module(load="imfile" mode="inotify")
 
-ruleset(name="fwdapachetocentrallog"){
+ruleset(name="fwdfail2bantocentrallog"){
             action(type="omfwd"
-            name="apache"
+            name="fail2ban"
             template="RSYSLOG_TraditionalForwardFormat"
             queue.type="LinkedList" # In Memory Queue
-            queue.filename="fwd_q_apache" # File name to be used for the queue files.
+            queue.filename="fwd_q_fail2ban" # File name to be used for the queue files.
             queue.size="100000" # The maximum size of the queue in number of messages.
             action.resumeRetryCount="-1" # Sets how often an action is retried before it is considered to have failed. Failed actions discard messages. (-1 means eternal)
             queue.saveonshutdown="on" # This parameter specifies if data should be saved at shutdown.
-            Target="rsyslog.argo.grnet.gr" Port="6514" Protocol="tcp"
+            Target="{{ central_rsyslog.hostname }}" Port="{{ central_rsyslog.port }}" Protocol="tcp"
             StreamDriver="gtls"
             StreamDriverMode="1" # run driver in TLS-only mode
             StreamDriverAuthMode="x509/name"
-            StreamDriverPermittedPeers="*.argo.grnet.gr"
+            StreamDriverPermittedPeers="{{ central_rsyslog.permittedPeers }}"
             )
 }
 
 input(type="imfile"
-      File="/var/log/httpd/*log"
-      Tag="apache:"
-      ruleset="fwdapachetocentrallog"
+      File="/var/log/fail2ban.log"
+      Tag="fail2ban:"
+      ruleset="fwdfail2bantocentrallog"
 )
 
 

--- a/roles/commons/templates/rsyslog.conf.j2
+++ b/roles/commons/templates/rsyslog.conf.j2
@@ -12,6 +12,7 @@ $ModLoad imuxsock # provides support for local system logging (e.g. via logger c
 $ModLoad imjournal # provides access to the systemd journal
 #$ModLoad imklog # reads kernel messages (the same are read from journald)
 #$ModLoad immark  # provides --MARK-- message capability
+Module(load="imfile" mode="inotify")
 
 # Provides UDP syslog reception
 #$ModLoad imudp


### PR DESCRIPTION
* [X] Create by default a rsyslog configuration for Fail2ban.
* [X] Fail2ban log files `/var/log/fail2ban.log` ==> `/var/log/fail2ban/fail2ban.log`
* [X] Removed the rsyslog configuration for Apache ( the Apache role is responsible for this ).


## Related : 
* https://github.com/ARGOeu/argo-ansible/pull/475
* https://github.com/ARGOeu/argo-ansible/pull/476