### PR TITLE
apache/handlers: Added handler to restart rsyslog.

### DIFF
--- a/roles/apache/handlers/main.yml
+++ b/roles/apache/handlers/main.yml
@@ -6,3 +6,10 @@
     name: httpd
     enabled: yes
     state: restarted
+
+
+- name: restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted
+    enabled: true


### PR DESCRIPTION
* [X] Added handler for rsyslog.

> Because now apache role sends its own rsyslog configuration for apache and it's necessary to restart rsyslog to take advantage of the new configuration.


### Related
* https://github.com/ARGOeu/argo-ansible/pull/476