### PR TITLE
DEVOPS-513 : Add HAProxy probe.

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -2,6 +2,10 @@
 # defaults file for haproxy
 
 
+###############################################
+# ~~~~~~~~~~~~~~~~~ HAProxy ~~~~~~~~~~~~~~~~~ #
+###############################################
+
 ## global
 haproxy_global_maxconn: 10000
 # Info --> https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#maxconn
@@ -45,6 +49,21 @@ haproxy_frontend_port_bind: 80
 
 ## HTTP/2: If you want to enable HTTP/2
 #haproxy_http2: "alpn h2,http/1.1"
+
+
+
+
+###############################################
+# ~~~~~~~~~~~~~~ HAProxy probe ~~~~~~~~~~~~~~ #
+###############################################
+
+haproxy_monitoring_agent: false
+
+haproxy_probe:
+  git_url: https://github.com/armondressler/check_haproxy_health.git
+  git_version: master
+  installation_dir: /usr/lib64/nagios/plugins/check_haproxy_health/
+  venv_dir: /usr/lib64/nagios/plugins/check_haproxy_health/haproxy-env
 
 
 

--- a/roles/haproxy/tasks/haproxy-probe.yml
+++ b/roles/haproxy/tasks/haproxy-probe.yml
@@ -1,0 +1,65 @@
+---
+# tasks file for haproxy probe
+
+
+- name: Install all needed packages for probe including python3
+  yum:
+    name:
+      - python36
+      - python36-devel
+      - python36-setuptools
+      - python36-pip
+      - git
+    state: present
+  tags:
+    - haproxy_probe
+    - haproxy_probe:python
+
+
+- name: Install Virtualenv (with pip)
+  pip:
+    name: virtualenv
+    state: present
+    executable: pip3.6
+  tags:
+    - haproxy_probe
+    - haproxy_probe:python
+    - haproxy_probe:python:venv
+
+
+- name: Git clone check_haproxy_health - Nagios plugin to check HAProxy stats
+  git:
+    repo: "{{ haproxy_probe.git_url }}"
+    version: "{{ haproxy_probe.git_version }}"
+    dest: "{{ haproxy_probe.installation_dir }}"
+    force: yes
+  tags:
+    - haproxy_probe
+    - haproxy_probe:git
+    - haproxy_probe:install
+
+
+- name: Create a virtualenv and install the requirements
+  pip:
+    requirements: "{{ haproxy_probe.installation_dir }}/requirements.txt"
+    virtualenv: "{{ haproxy_probe.venv_dir }}"
+    #virtualenv: "{{ virtual_env_installation }}/authn-env"
+    virtualenv_python: python3.6
+    #state: forcereinstall
+  tags:
+    - haproxy_probe
+    - haproxy_probe:git
+    - haproxy_probe:install
+
+
+- name: Ensure the bash script have execution privileges
+  file:
+    path: "{{ haproxy_probe.installation_dir }}/check_haproxy_health.py"
+    mode: '0755'
+    owner: root
+    group: nagios
+  tags:
+    - haproxy_probe
+    - haproxy_probe:privileges
+
+

--- a/roles/haproxy/tasks/haproxy.yml
+++ b/roles/haproxy/tasks/haproxy.yml
@@ -48,6 +48,16 @@
    group: haproxy
   tags: haproxy_install
 
+
+- name: Find icinga group id
+  shell: id -g icinga
+  register: icinga_group_id
+  when: haproxy_monitoring_agent | default(false) | bool
+  tags:
+    - haproxy_install
+    - haproxy_install:icinga_group_id
+
+
 - name: configure haproxy
   template:
    src: haproxy_template.cfg.j2
@@ -82,3 +92,14 @@
    name: rh-haproxy18-haproxy
    enabled: true
   tags: haproxy_install
+
+
+- name: Add HAProxy monitoring agent probe
+  include: haproxy-probe.yml
+  when: haproxy_monitoring_agent | default(false) | bool
+  tags:
+    - haproxy_install
+    - haproxy_probe
+
+
+

--- a/roles/haproxy/templates/haproxy_template.cfg.j2
+++ b/roles/haproxy/templates/haproxy_template.cfg.j2
@@ -41,7 +41,9 @@ global
     master-worker                                           # Launch a "master" which will monitor the "workers".
 
     # turn on stats unix socket
-    stats socket /var/lib/haproxy/stats.sock mode 660 level admin
+    stats socket /var/lib/haproxy/stats.sock {% if icinga_group_id is defined %}gid {{icinga_group_id.stdout}}{% endif %} mode 660 level admin
+
+
 
     # SSL global configuration
 


### PR DESCRIPTION
* [X] HAProxy probe.

That probe works with HAProxy socket in order to be able to take HAProxy metrics. That's why we also set the group id of the icinga user in `haproxy.cfg`. If we need to isntall it, we have to set `haproxy_monitoring_agent: true`.
Default installation path : `/usr/lib64/nagios/plugins/check_haproxy_health/`