### PR TITLE
argo-api-authn/tasks/update.yml: Get the uuid

### DIFF
--- a/roles/argo-api-authn/tasks/update.yml
+++ b/roles/argo-api-authn/tasks/update.yml
@@ -18,3 +18,23 @@
     name: argo-api-authn
     state: restarted
   tags: authn_update
+
+
+- name: Get the uuid of ams service type
+  uri:
+    url: "https://{{ authn_host_domain_name }}:{{ authn_service_port }}/v1/service-types?key={{ authn_service_token }}"
+    method: GET
+    body: "{{ lookup('template', 'authn_create_service_type_body.j2') }}"
+    body_format: json
+    return_content: yes
+    status_code: 200
+    validate_certs: no
+  retries: 3
+  delay: 3
+  register: get_uuid_response
+  tags:
+    - authn_update
+    - authn_init:get_service_type
+
+
+


### PR DESCRIPTION
* [X] Added task `Get the uuid of ams service type`

As in the installation process, we also want the UUID of AMS service type.

So, now we can also use the update playbook : https://github.com/ARGOeu/argo-ansible/blob/devel/update.yml#L8-L14

### Fixes : 
* https://jenkins.einfra.grnet.gr/job/ARGO-utils/job/deploy-argo-api-authn/46/console