### PR TITLE
Freeze pyyaml version

### DIFF
--- a/roles/swagger/tasks/main.yml
+++ b/roles/swagger/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Install PyYAML
   tags: swagger
-  pip: name=pyYAML state=latest
+  pip: name=pyYAML version=5.4.1
 
 
 - name: Create /tmp/swagger folder


### PR DESCRIPTION
Set version of PyYaml to the latest that supports python2. We run the job in python2 environment this should be a temporary fix and later we should migrate everything to python3