### PR TITLE
Fixes when we deploy AMS cluster without push server.

### DIFF
--- a/ams-cluster-playbook.yml
+++ b/ams-cluster-playbook.yml
@@ -4,6 +4,7 @@
 - hosts: all
   become: yes
   roles:
+    - { role: commons,                 task: selinux,         tags: disable_selinux       }
     - { role: commons,                 task: timezone,        tags: timezone              }
     - { role: commons,                 task: repos,           tags: repos                 }
     - { role: commons,                 task: basic_utils,     tags: basic_utils           }
@@ -16,6 +17,12 @@
     - { role: nickhammond.logrotate,                          tags: logrotate             }
     #- { role: commons,                 task: is_monitored,    tags: monitored             }
     #- { role: commons,                 task: backupamsmongo,  tags: rsyslog_conf          }
+
+
+- hosts: icinga_agent
+  become: yes
+  roles:
+     - { role: icinga_agent, tags: deploy_icinga_agent }
 
 
 - hosts: ams_cluster

--- a/roles/ams/tasks/deploy.yml
+++ b/roles/ams/tasks/deploy.yml
@@ -35,6 +35,7 @@
     - ams_certs
     - ams_config
   notify: restart argo-messaging
+  when: ams_push_enabled is defined and ams_push_enabled | default(false) | bool
 
 - name: Copy CA file to validate push server
   copy: src=private_files/{{ inventory_hostname }}/PushCA.crt
@@ -46,6 +47,7 @@
     - ams_certs
     - ams_config
   notify: restart argo-messaging
+  when: ams_push_enabled is defined and ams_push_enabled | default(false) | bool
 
 - name: Configure argo-messaging api
   template: src=config.json.j2

--- a/roles/ams/templates/config.json.j2
+++ b/roles/ams/templates/config.json.j2
@@ -12,7 +12,6 @@
   {% if ams_service_token %}
   "service_token":"{{ams_service_token}}",
   {% endif %}
-  "log_level": "{{ams_log_level}}",
   {% if ams_push_enabled %}
   "push_enabled": {{ams_push_enabled}},
   "push_server_host": "{{ams_push_server_host}}",
@@ -21,7 +20,8 @@
   {% if ams_push_tls_enabled %}
   "push_tls_enabled": {{ams_push_tls_enabled}},
   "verify_push_server": {{ams_verify_push_server}},
-  "certificate_authorities_dir": "/var/www/argo-messaging/cas"
+  "certificate_authorities_dir": "/var/www/argo-messaging/cas",
   {% endif %}
   {% endif %}
+  "log_level": "{{ams_log_level}}"
 }

--- a/roles/haproxy/templates/haproxy_template.cfg.j2
+++ b/roles/haproxy/templates/haproxy_template.cfg.j2
@@ -126,7 +126,7 @@ listen stats
 # main frontend which proxys to the backends
 #---------------------------------------------------------------------
 
-frontend  {{haproxy_frontend}}
+frontend  {{haproxy_frontend | default(inventory_hostname) }}
     # Logged also an HTTP request header
     http-request    capture req.hdr(Host) len 30
     http-request    capture req.hdr(User-Agent) len 100

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -13,6 +13,26 @@
     - git
 
 
+- name: Instsall python2-pip
+  package:
+    name: python2-pip
+    state: latest
+  tags:
+    - python2
+    - python2-pip
+
+- name: Set specific version of pip
+  pip:
+    name:
+      - pip>10,<21.0
+    state: forcereinstall
+    executable: pip2
+    extra_args: --upgrade
+  tags:
+    - python2
+    - python2-pip
+    - python2-pip-fix
+
 - name: install pymongo==3.12.3
   pip:
     name: pymongo==3.12.3


### PR DESCRIPTION
* [X] Add SELinux disable.
* [X] Add icinga agent role.
* [X] Copy CA file to validate push server **only** when `ams_push_enabled`.
* [X] Fix comma in ams config file.
* [X] HAProxy configuration file `haproxy_frontend` or `default(inventory_hostname)`
* [X] Fix issue with old and latest pip version (motop)