### PR TITLE
Install motop only with Python 2.7 & pip2.7

### DIFF
--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -12,9 +12,24 @@
     - mongodb-org-server
     - git
 
+
+- name: install pymongo==3.12.3
+  pip:
+    name: pymongo==3.12.3
+    state: present
+    executable: pip2.7
+  tags:
+    - pymongo
+    - motop
+
 - name: install motop
   pip:
     name: git+https://github.com/tart/motop.git
+    state: present
+    executable: pip2.7
+  tags:
+    - motop
+
 
 - name: create mongo replicated folder
   file:


### PR DESCRIPTION
* [X] Fixed installation issue with `motop` tool.


<details>
  <summary>Before :x:  </summary>

```bash
TASK [mongodb : install motop] ***********************************************************************************************************************************************
task path: /ansible/argo-ansible-deploy/argo-ansible/roles/mongodb/tasks/main.yml:27
fatal: [mongo-probe-test]: FAILED! => changed=false 
  cmd:
  - /usr/bin/pip2.7
  - install
  - git+https://github.com/tart/motop.git
  msg: |-
    stdout: Collecting git+https://github.com/tart/motop.git
      Cloning https://github.com/tart/motop.git to ./pip-xOYWmb-build
    Collecting pymongo (from motop==4.2)
      Downloading https://files.pythonhosted.org/packages/3f/ff/7ec17064d403799d644f7db9c2e99202441849aebe771efe3199f3dd9076/pymongo-4.0.1.tar.gz (768kB)
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/tmp/pip-build-Jn3Iua/pymongo/setup.py", line 9, in <module>
            raise RuntimeError("Python version >= 3.6 required.")
        RuntimeError: Python version >= 3.6 required.
  
        ----------------------------------------
  
    :stderr: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-Jn3Iua/pymongo/
    You are using pip version 8.1.2, however version 21.3.1 is available.
    You should consider upgrading via the 'pip install --upgrade pip' command.
```

</details>


<details>
  <summary>Now :heavy_check_mark:   </summary>

```bash
TASK [mongodb : install pymongo==3.12.3] ***********************************************************************************************************************************************
task path: /ansible/argo-ansible-deploy/argo-ansible/roles/mongodb/tasks/main.yml:16
changed: [mongo-probe-test] => changed=true 
  cmd:
  - /usr/bin/pip2.7
  - install
  - pymongo==3.12.3
  name:
  - pymongo==3.12.3
  requirements: null
  state: present
  stderr: |-
    You are using pip version 8.1.2, however version 21.3.1 is available.
    You should consider upgrading via the 'pip install --upgrade pip' command.
  stderr_lines: <omitted>
  stdout: |-
    Collecting pymongo==3.12.3
      Using cached https://files.pythonhosted.org/packages/fc/c7/fdcd1e724029f6d053856e4ce2fef3fd7b6a9e962585177a56da3a5829fc/pymongo-3.12.3-cp27-cp27mu-manylinux1_x86_64.whl
    Installing collected packages: pymongo
    Successfully installed pymongo-3.12.3
  stdout_lines: <omitted>
  version: null
  virtualenv: null

TASK [mongodb : install motop] ***********************************************************************************************************************************************
task path: /ansible/argo-ansible-deploy/argo-ansible/roles/mongodb/tasks/main.yml:27
changed: [mongo-probe-test] => changed=true 
  cmd:
  - /usr/bin/pip2.7
  - install
  - git+https://github.com/tart/motop.git
  name:
  - git+https://github.com/tart/motop.git
  requirements: null
  state: present
  stderr: |-
    You are using pip version 8.1.2, however version 21.3.1 is available.
    You should consider upgrading via the 'pip install --upgrade pip' command.
  stderr_lines: <omitted>
  stdout: |-
    Collecting git+https://github.com/tart/motop.git
      Cloning https://github.com/tart/motop.git to ./pip-OrLjwK-build
    Requirement already satisfied (use --upgrade to upgrade): pymongo in /usr/lib64/python2.7/site-packages (from motop==4.2)
    Collecting argparse (from motop==4.2)
      Downloading https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl
    Installing collected packages: argparse, motop
      Running setup.py install for motop: started
        Running setup.py install for motop: finished with status 'done'
    Successfully installed argparse-1.4.0 motop-4.2
  stdout_lines: <omitted>
  version: null
  virtualenv: null
META: ran handlers
META: ran handlers
```


```bash
# motop --version
motop 4.2
```

</details>