### PR TITLE
DEVOPS-467 : Fix failed_when in firewalld tasks.

### DIFF
--- a/roles/commons/tasks/firewall.yml
+++ b/roles/commons/tasks/firewall.yml
@@ -44,14 +44,18 @@
   with_items: "{{firewall_zones}}"
   notify: restart firewall
   tags: firewall
-  ignore_errors: true
+  register: new_zone_result
+  failed_when: new_zone_result is failed and "NAME_CONFLICT" not in new_zone_result.stderr
+  changed_when: new_zone_result is changed and "NAME_CONFLICT" not in new_zone_result.stderr
 
 - name: Create firewall new services
   command: firewall-cmd --permanent --new-service="{{item.name}}"
   with_items: "{{firewall_services}}"
   notify: restart firewall
   tags: firewall
-  ignore_errors: true
+  register: new_service_result
+  failed_when: new_service_result is failed and "NAME_CONFLICT" not in new_service_result.stderr
+  changed_when: new_service_result is changed and "NAME_CONFLICT" not in new_service_result.stderr
 
 - name: Add port to services
   command: firewall-cmd --permanent --service="{{item.name}}" --add-port={{item.port}}


### PR DESCRIPTION
* [X] Fixed failed errors with firewalld.


<details>
  <summary>Before :x:  </summary>

```bash
TASK [commons : Create firewall new zones] *******************************************************************************************
task path: /ansible/argo-ansible-deploy/argo-ansible/roles/commons/tasks/firewall.yml:42
failed: [test_vm] (item=icinga) => changed=true 
  ansible_loop_var: item
  cmd:
  - firewall-cmd
  - --permanent
  - --new-zone=icinga
  delta: '0:00:00.442815'
  end: '2022-01-21 13:19:38.281205'
  item: icinga
  msg: non-zero return code
  rc: 26
  start: '2022-01-21 13:19:37.838390'
  stderr: 'Error: NAME_CONFLICT: new_zone(): ''icinga'''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
...ignoring
```

```bash
TASK [commons : Create firewall new services] *******************************************************************************************
task path:/ansible/argo-ansible-deploy/argo-ansible/roles/commons/tasks/firewall.yml:49
failed: [test_vm] (item={'name': 'mongodb', 'port': '27017/tcp'}) => changed=true 
  ansible_loop_var: item
  cmd:
  - firewall-cmd
  - --permanent
  - --new-service=mongodb
  delta: '0:00:00.397671'
  end: '2022-01-21 13:19:41.415582'
  item:
    name: mongodb
    port: 27017/tcp
  msg: non-zero return code
  rc: 26
  start: '2022-01-21 13:19:41.017911'
  stderr: 'Error: NAME_CONFLICT: new_service(): ''mongodb'''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
...ignoring
```

</details>


<details>
  <summary>Now :heavy_check_mark:   </summary>

```bash
TASK [commons : Create firewall new zones] *******************************************************************************************
ok: [test_vm] => (item=icinga) => changed=false 
  ansible_loop_var: item
  cmd:
  - firewall-cmd
  - --permanent
  - --new-zone=icinga
  delta: '0:00:00.443080'
  end: '2022-01-21 13:45:11.963884'
  failed_when_result: false
  item: icinga
  msg: non-zero return code
  rc: 26
  start: '2022-01-21 13:45:11.520804'
  stderr: 'Error: NAME_CONFLICT: new_zone(): ''icinga'''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```


```bash
TASK [commons : Create firewall new services] *******************************************************************************************
ok: [test_vm] => (item={'name': 'mongodb', 'port': '27017/tcp'}) => changed=false 
  ansible_loop_var: item
  cmd:
  - firewall-cmd
  - --permanent
  - --new-service=mongodb
  delta: '0:00:00.543537'
  end: '2022-01-21 13:45:15.383636'
  failed_when_result: false
  item:
    name: mongodb
    port: 27017/tcp
  msg: non-zero return code
  rc: 26
  start: '2022-01-21 13:45:14.840099'
  stderr: 'Error: NAME_CONFLICT: new_service(): ''mongodb'''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```

</details>