### PR TITLE
REC-199 RSeval role update default env vars

### DIFF
--- a/roles/rseval/files/.env
+++ b/roles/rseval/files/.env
@@ -1,2 +1,5 @@
-RS_EVALUATION_MONGO_URI=mongodb://localhost:27017/rsmetrics
-RS_EVALUATION_METRIC_DESC_DIR=/var/www/rseval/data/metric_descriptions
+RSEVAL_MONGO_URI=mongodb://localhost:27017/rsmetrics
+RSEVAL_METRIC_DESC_DIR=../metric_descriptions
+RSEVAL_SUPERVISOR_RPC_SERVER=http://localhost:9001/RPC2
+RSEVAL_STREAM_USER_ACTIONS_JOBNAME=stream-user-actions
+RSEVAL_STREAM_MP_DB_EVENTS_JOBNAME=stream-mp-db-events


### PR DESCRIPTION
Related to latest update (https://github.com/ARGOeu/eosc-recommender-metrics/pull/119) that shortens the env var names