### PR TITLE
Temporarily deactivate mongo role in rseval playbook

### DIFF
--- a/rseval-playbook.yml
+++ b/rseval-playbook.yml
@@ -13,11 +13,11 @@
     - { role: commons,                 task: cert,            tags: cert                  }
 
 
-- hosts: mongo
-  tags: deploy
-  become: yes
-  roles:
-    - { role: mongodb,    task: main,     tags: mongodb }
+# - hosts: mongo
+#   tags: deploy
+#   become: yes
+#   roles:
+#     - { role: mongodb,    task: main,     tags: mongodb }
 
 - hosts: apache
   tags: deploy


### PR DESCRIPTION
Due to issues with mongo 4.4 and the current mongo role, temporarily deactivate mongo role from rseval playbook