### PR TITLE
PIDMR-45 Create ansible role for frontend deployments

### DIFF
--- a/roles/frontend/defaults/main.yml
+++ b/roles/frontend/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# defaults file for frontend
+checkout_url: "" # point to a github repo: https://github.com/argoeu/example.git
+checkout_branch: devel # which branch will be checked out
+checkout_path: /tmp/frontend # where the project will be downloaded locally
+
+
+# default url to add nodejs repo in centos 7
+nodejs_yum_repo_url: 'https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm'
+# config files might have a list of config files to be passed to the repo before building
+# config_files:
+#  - src: config.json # must have file at private files
+#    dest: '{{repo_path}}/src/config.json'
+config_files: []
+
+# folder for build to be placed and served
+www_path: "/var/www/{{inventory_hostname}}/"
+

--- a/roles/frontend/handlers/main.yml
+++ b/roles/frontend/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# handlers file for frontend
+
+- name: restart httpd
+  service:
+    name: httpd
+    enabled: yes
+    state: restarted

--- a/roles/frontend/tasks/main.yml
+++ b/roles/frontend/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# tasks file for frontend
+
+- include: "{{task}}.yml"

--- a/roles/frontend/tasks/react-based.yml
+++ b/roles/frontend/tasks/react-based.yml
@@ -1,0 +1,81 @@
+---
+# tasks file for frontend react
+
+- name: update yum cache
+  yum:
+    update_cache: true
+
+- name: Install reqired packages
+  yum:
+    name:
+      - git
+      - curl
+      - wget
+
+- name: Add nodejs repo 
+  yum:
+    name: "{{ nodejs_yum_repo_url }}"
+    state: present
+
+- name: Install NodeJs
+  yum:
+    name:
+      - nodejs
+
+- name: Check clone repo dest directory is absent
+  file:
+      state: absent
+      path: "{{ checkout_path }}/"
+  tags:
+    - update-frontend
+    - update
+
+- name: Clone a private repository
+  git:
+    repo: "{{ checkout_url }}"
+    dest: "{{ checkout_path }}"
+    version: "{{ checkout_branch }}"
+    force: true
+    accept_hostkey: true
+  tags:
+    - update-frontend
+    - update
+
+    
+- name: Install packages based on package.json using the npm
+  npm:
+    path: "{{ checkout_path }}"
+    state: present
+  tags:
+    - update-frontend
+    - update
+    
+- name: Copy config files
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dst }}"
+    remote_src: false
+  loop: "{{ config_files }}"
+  tags:
+    - update-frontend
+    - update
+    
+
+- name: Build app
+  command: npm run build
+  args:
+    chdir: "{{ checkout_path }}"
+  tags:
+    - update-frontend
+    - update
+    
+- name: Copy folder to a www folder destination
+  copy:
+    src: "{{ checkout_path }}/build/"
+    dest: "{{ www_path }}"
+    remote_src: true
+  notify:
+    - restart httpd
+  tags:
+    - update-frontend
+    - update


### PR DESCRIPTION
Add a generic frontend role to deploy frontend/ui builds.
Frontend role has a specific task file: `react-based.yml` that implements a simple react/nodejs ui build deployment. Others can be added in the future

- [x] Install specific nodejs repo - configurable for selecting specific nodejs versions
- [x] checkout a specific frontend project repo and branch into a local folder (all configurable) 
- [x] Given a list of configuration files (or other assets) copy those files to specific destinations in the checkout folder (optional)
- [x] Create an optimised build
- [x] Copy the build contents to a destination www folder (configurable)
- [x] Restart the apache if needed
