### PR TITLE
CAT-85 Add version and build info in frontend role

### DIFF
--- a/roles/frontend/defaults/main.yml
+++ b/roles/frontend/defaults/main.yml
@@ -3,6 +3,8 @@
 checkout_url: "" # point to a github repo: https://github.com/argoeu/example.git
 checkout_branch: devel # which branch will be checked out
 checkout_path: /tmp/frontend # where the project will be downloaded locally
+build_date: ""
+build_commit_hash: ""
 
 
 # default url to add nodejs repo in centos 7

--- a/roles/frontend/tasks/react-based.yml
+++ b/roles/frontend/tasks/react-based.yml
@@ -41,6 +41,19 @@
     - update-frontend
     - update
 
+- name: Get Git repo info
+  git:
+    repo: "{{ checkout_path }}"
+    rev: HEAD
+  register: git_repo_info
+
+- name: Set build_commit_hash variable
+  set_fact:
+    build_commit_hash: "{{ git_repo_info.after }}"
+  tags:
+    - update-frontend
+    - update
+
     
 - name: Install packages based on package.json using the npm
   npm:
@@ -59,12 +72,22 @@
   tags:
     - update-frontend
     - update
-    
 
-- name: Build app
+- name: set build_date
+  set_fact:
+    build_date: "{{ ansible_date_time.iso8601 }}"
+  tags:
+    - update-frontend
+    - update
+
+- name: Build app with additional build info from environment vars
   command: npm run build
   args:
     chdir: "{{ checkout_path }}"
+  environment:
+    REACT_APP_BUILD_COMMIT_URL: '{{ checkout_url | regex_replace("\.git$", "/tree/" ~ build_commit_hash) }}'
+    REACT_APP_BUILD_COMMIT_HASH: '{{ build_commit_hash }}'
+    REACT_APP_BUILD_DATE: '{{build_date}}'
   tags:
     - update-frontend
     - update


### PR DESCRIPTION
# 🎯 Goal
Update frontend react deploy task to add build information to the produced artifact. This requires to gather the following information:
- github repo used: This is already stored in `checkout_repo` ansible var (need some regex manipulation to produce `http://gitub.com/org/repo/tree/{commit}`
- github commit hash: This is retrieved in a new task and stored to the `build_commit_hash` variable
- build date: This is calculated in a new task and stored in iso format in the var `build_date`

# 🏗️ Implementation
- [x] Add task to get commit hash
- [x] Add task to calculate current date in iso format
- [x] Update npm build task to get the required information into correct `REACT_APP_` environment variables that will be used in the baked artifact